### PR TITLE
🔧 Modernize MNT Designer packaging, CI, and compatibility

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,8 +8,10 @@ on:
     - cron: "7 3 * * 5"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   analyze:
@@ -27,18 +29,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
+          build-mode: none
           queries: +security-and-quality
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
-
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,52 +9,87 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
-  KNOWN_HOSTS: ${{ secrets.KNOWN_HOSTS }}
+permissions: {}
 
 jobs:
+  quality:
+    name: Quality checks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Run pre-commit
+        run: pipx run pre-commit run --all-files --show-diff-on-failure
+
   build_wheel:
     name: Build wheel
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v7
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.9"
+          python-version: "3.14"
         name: Install Python
       - name: Build wheel
         run: pipx run build --wheel
-      - name: Install wheel
-        run: python -m pip install --verbose dist/*.whl
-      - uses: actions/upload-artifact@v7
+      - name: Check wheel
+        run: pipx run twine check dist/*.whl
+      - name: Install and test wheel
+        run: |
+          python -m pip install --verbose pytest dist/*.whl
+          python -m pytest
+          python -m pip check
+          mnt-designer --help
+          mnt.designer --help
+      - if: github.event_name == 'release'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: "artifact-wheel"
+          name: artifact-wheel
           path: dist/*.whl
+          if-no-files-found: error
 
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v7
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.9"
+          python-version: "3.11"
         name: Install Python
       - name: Build sdist
         run: pipx run build --sdist
-      - name: Install sdist
-        run: python -m pip install --verbose dist/*.tar.gz
-      - uses: actions/upload-artifact@v7
+      - name: Check source distribution
+        run: pipx run twine check dist/*.tar.gz
+      - name: Install and test source distribution
+        run: |
+          python -m pip install --verbose pytest dist/*.tar.gz
+          python -m pytest
+          python -m pip check
+          mnt-designer --help
+          mnt.designer --help
+      - if: github.event_name == 'release'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          name: artifact-sdist
           path: dist/*.tar.gz
+          if-no-files-found: error
 
   upload_pypi:
     if: github.event_name == 'release' && github.event.action == 'published'
@@ -65,10 +100,11 @@ jobs:
       url: https://pypi.org/p/mnt.designer
     permissions:
       id-token: write
-    needs: [build_wheel, build_sdist]
+    needs: [quality, build_wheel, build_sdist]
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: artifact
+          pattern: artifact-*
           path: dist
-      - uses: pypa/gh-action-pypi-publish@release/v1
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,21 +4,26 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, reopened, synchronize]
   pull_request_target:
     types: [opened, reopened, synchronize]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   update_release_draft:
+    if: github.event_name == 'push'
     permissions:
       contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
+
+  auto_label:
+    if: github.event_name == 'pull_request_target'
+    permissions:
+      contents: read
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v7
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: release-drafter/release-drafter/autolabeler@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,17 +10,16 @@
 ci:
   autoupdate_commit_msg: "⬆️🪝 update pre-commit hooks"
   autofix_commit_msg: "🎨 pre-commit fixes"
-  skip: [mypy]
 
 repos:
-  # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.5.0"
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
       - id: check-docstring-first
       - id: check-merge-conflict
+      - id: check-symlinks
       - id: check-toml
       - id: check-yaml
       - id: debug-statements
@@ -28,65 +27,15 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
 
-  # Handling unwanted unicode characters
-  - repo: https://github.com/sirosen/texthooks
-    rev: "0.6.2"
-    hooks:
-      - id: fix-ligatures
-      - id: fix-smartquotes
-        exclude: "mnt/bench/templates/legal.html"
-
-  # Python linting using ruff
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.3
-    hooks:
-      #- id: ruff
-      #  args: ["--fix", "--show-fixes"]
-      - id: ruff-format
-
-  # Also run Black on examples in the documentation
-  - repo: https://github.com/asottile/blacken-docs
-    rev: "1.16.0"
-    hooks:
-      - id: blacken-docs
-        additional_dependencies: [black==23.*]
-
-  # Clean jupyter notebooks
-  - repo: https://github.com/srstevenson/nb-clean
-    rev: "3.1.0"
-    hooks:
-      - id: nb-clean
-  # Check for spelling
   - repo: https://github.com/codespell-project/codespell
-    rev: "v2.2.6"
+    rev: v2.4.3
     hooks:
       - id: codespell
-        args: ["-L", "wille,linz"]
-        exclude: "mnt/bench/templates/legal.html"
-
-  # Format configuration files with prettier
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v3.0.3"
-    hooks:
-      - id: prettier
-        types_or: [yaml, markdown, html, css, javascript, json]
+        args: ["-L", "wille"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.1
+    rev: v0.16.5
     hooks:
-      - id: ruff
-        args: ["--fix", "--show-fixes"]
-
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.6.1
-    hooks:
-      - id: mypy
-        files: ^(src|setup.py)
-        args: []
-        additional_dependencies:
-          - importlib_resources
-          - pytest
-          - types-setuptools
-          - types-requests
-          - types-tqdm
-          - types-flask
+      - id: ruff-check
+        args: [--fix, --show-fixes]
+      - id: ruff-format

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-include src/mnt/designer/templates/*
-include src/mnt/designer/static/*

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![PyPI](https://img.shields.io/pypi/v/mnt.designer?logo=pypi&style=flat-square)](https://pypi.org/project/mnt.designer/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 [![Bindings](https://img.shields.io/github/actions/workflow/status/cda-tum/mnt-designer/deploy.yml?branch=main&style=flat-square&logo=github&label=python)](https://github.com/cda-tum/mnt-designer/actions/workflows/deploy.yml)
-[![Code style: black][black-badge]][black-link]
+[![Code style: Ruff][ruff-badge]][ruff-link]
 
 # MNT Designer: A Comprehensive Design Tool for Field-coupled Nanocomputing (FCN)
 
@@ -16,8 +16,8 @@ MNT Designer is a comprehensive, fully open-source,
 GUI-based tool that advances the design of Field-coupled
 Nanocomputing circuits from high-level logic specifications
 through to fabrication-ready, cell-level layouts. By unifying
-previously separate stages such as physical design, “on-the-fly” 
-gate design, and verification in a graphical user interface, 
+previously separate stages such as physical design, “on-the-fly”
+gate design, and verification in a graphical user interface,
 the tool streamlines an otherwise fragmented workflow.
 Specifically, it enables researchers and designers to import
 and edit high-level logic descriptions, generate and refine
@@ -25,13 +25,13 @@ gate-level layouts, verify design-rule compliance, and export
 completed designs for simulation and fabrication.
 The modularity and scalability of the proposed approach
 accommodate both exact and heuristic algorithms, offering
-flexibility in tackling the wide range of problems and constraints 
+flexibility in tackling the wide range of problems and constraints
 inherent to FCN technologies. The ability to manually adjust layouts
 alongside automated post-layout optimization algorithms further empowers experts to explore custom
 solutions for performance-critical or domain-specific designs.
 Moreover, the integrated gate-design functionality for SiDBs
 facilitates rapid prototyping and testing of new concepts.
-Overall, by integrating these capabilities into a single, user-friendly 
+Overall, by integrating these capabilities into a single, user-friendly
 environment, the presented tool fills a critical gap in
 existing FCN design tools. It thereby accelerates research and
 development in nanoscale computing, ultimately paving the
@@ -41,33 +41,53 @@ Related publication presented at DATE: [paper](https://www.cda.cit.tum.de/files/
 
 # Usage of MNT Designer
 
-If you do not have a virtual environment set up, the following steps outline one possible way to do so.
-First, install virtualenv:
+MNT Designer supports Python 3.11–3.14 and uses [pyfiction](https://pypi.org/project/mnt.pyfiction/) 0.8.0 or newer.
+Create a virtual environment using your Python installation:
 
 ```console
-$ pip install virtualenv
+$ python3 -m venv .venv
+$ source .venv/bin/activate
 ```
 
-Then create a new virtual environment in your project folder and activate it:
+For fish, activate with `source .venv/bin/activate.fish` instead. On Windows PowerShell, use `.venv\Scripts\Activate.ps1`.
+Install and start Designer:
 
 ```console
-$ mkdir mnt_designer
-$ cd mnt_designer
-$ python -m venv venv
-$ source venv/bin/activate
+$ python -m pip install --upgrade mnt.designer
+$ mnt-designer
 ```
 
-MNT Designer can be installed via pip:
+The interface opens at <http://127.0.0.1:5001>. The original `mnt.designer` command remains supported.
+Use `--help` to see the options, or choose another port and open the browser yourself:
 
 ```console
-(venv) $ pip install mnt.designer
+$ mnt-designer --port 5053 --no-browser
 ```
 
-and then started locally using this command:
+## Development
 
+Clone the repository and install it in a Python 3.11+ virtual environment:
+
+```console
+$ git clone https://github.com/cda-tum/mnt-designer.git
+$ cd mnt-designer
+$ python -m pip install -e '.[test]'
+$ python -m pytest
+$ mnt-designer
 ```
-(venv) $ mnt.designer
-```
+
+The editable installation is needed to share the `mnt` namespace with pyfiction; setting `PYTHONPATH` alone is not sufficient.
+Run the repository checks with `pre-commit run --all-files` after installing [pre-commit](https://pre-commit.com/).
+
+## Hosting notes
+
+The built-in server is intended for local use and binds to loopback by default. For deployment, use a production WSGI
+server with `mnt.designer.app:app` and **one worker process**: layouts and logic networks are held in process-local memory,
+not shared between workers, and are lost when the server restarts. Export work you want to keep.
+
+Designer generates a random session secret at startup. Set `MNT_DESIGNER_SECRET_KEY` to a securely generated secret if you
+need a stable signing key; this does not make the in-memory layouts persistent. See Flask's
+[deployment guidance](https://flask.palletsprojects.com/en/stable/deploying/) before exposing the application publicly.
 
 # References
 
@@ -91,5 +111,5 @@ In case you are using MNT Designer in your work, we would be thankful if you ref
 }
 ```
 
-[black-badge]: https://img.shields.io/badge/code%20style-black-000000.svg
-[black-link]: https://github.com/psf/black
+[ruff-badge]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
+[ruff-link]: https://github.com/astral-sh/ruff

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ The built-in server is intended for local use and binds to loopback by default. 
 server with `mnt.designer.app:app` and **one worker process**: layouts and logic networks are held in process-local memory,
 not shared between workers, and are lost when the server restarts. Export work you want to keep.
 
+Request-body reads are limited to 5 MiB, including multipart upload overhead, before native layout or Verilog parsing.
+Rejected imports and editor saves leave the current layout and code unchanged. Configure a matching request-size limit
+in your reverse proxy when hosting Designer, including for streamed requests without a content length.
+
 Designer generates a random session secret at startup. Set `MNT_DESIGNER_SECRET_KEY` to a securely generated secret if you
 need a stable signing key; this does not make the in-memory layouts persistent. See Flask's
 [deployment guidance](https://flask.palletsprojects.com/en/stable/deploying/) before exposing the application publicly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-    "setuptools>=61",
-    "setuptools_scm>=7",
+    "setuptools>=77.0.3",
+    "setuptools-scm>=8.1",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -12,141 +12,82 @@ readme = "README.md"
 authors = [
     { name = "Simon Hofmann", email = "simon.t.hofmann@tum.de" },
 ]
-keywords = ["MNT",  "field-coupled nanocomputing", "design"]
-license = { file = "LICENSE" }
-requires-python = ">=3.9"
+keywords = ["MNT", "field-coupled nanocomputing", "design"]
+license = "MIT"
+license-files = ["LICENSE"]
+requires-python = ">=3.11"
 dynamic = ["version"]
 
 dependencies = [
-    "flask>=2.0.0",
-    "packaging>=21.0",
-    "requests>=2.31.0",
-    "mnt.pyfiction>=0.6.8"
+    "flask>=3.0.0",
+    "mnt.pyfiction>=0.8.0",
 ]
 
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: MacOS",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Intended Audience :: Science/Research",
     "Natural Language :: English",
     "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
 ]
 
 [project.optional-dependencies]
-test = ["pytest>=7.2"]
-coverage = ["mnt.designer[test]", "pytest-cov[toml]"]
-dev = ["mnt.designer[coverage]"]
+test = ["pytest>=8.2.1"]
+coverage = ["mnt.designer[test]", "pytest-cov"]
 
 [project.scripts]
-"mnt.designer" = "mnt.designer.app:start_server"
+"mnt.designer" = "mnt.designer.app:main"
+"mnt-designer" = "mnt.designer.app:main"
 
 [project.urls]
-Homepage = "https://github.com/cda-tum/mntdesigner"
-"Bug Tracker" = "https://github.com/cda-tum/mntdesigner/issues"
-Discussions = "https://github.com/cda-tum/mntdesigner/discussions"
+Homepage = "https://github.com/cda-tum/mnt-designer"
+"Bug Tracker" = "https://github.com/cda-tum/mnt-designer/issues"
+Discussions = "https://github.com/cda-tum/mnt-designer/discussions"
 Research = "https://www.cda.cit.tum.de/research/nanotech/"
+
+[tool.setuptools]
+# Keep editable installs compatible with mnt.pyfiction's shared namespace.
+package-dir = { "mnt" = "src/mnt" }
+packages = ["mnt", "mnt.designer"]
+include-package-data = false
+
+[tool.setuptools.package-data]
+"mnt.designer" = [
+    "templates/*.html",
+    "static/*.ico",
+    "static/*.svg",
+    "static/css/*.css",
+    "static/js/*.js",
+    "static/gates/*.svg",
+]
 
 [tool.setuptools_scm]
 
 [tool.pytest.ini_options]
-minversion = "7.2"
 testpaths = ["tests"]
-addopts = ["-ra", "--strict-markers", "--strict-config", "--showlocals"]
-log_cli_level = "INFO"
-xfail_strict = true
+addopts = ["-ra", "--strict-config", "--strict-markers"]
 
 [tool.coverage.run]
 source = ["mnt.designer"]
 
 [tool.coverage.report]
-exclude_also = [
-    '\.\.\.',
-    'if TYPE_CHECKING:',
-]
 show_missing = true
 skip_empty = true
 precision = 1
 
-[tool.mypy]
-mypy_path = "$MYPY_CONFIG_FILE_DIR/src"
-files = ["src", "tests", "setup.py"]
-python_version = "3.9"
-strict = true
-show_error_codes = true
-enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
-warn_unreachable = true
-explicit_package_bases = true
-pretty = true
-
-[[tool.mypy.overrides]]
-module = ["joblib.*", "networkx.*", "pandas.*"]
-ignore_missing_imports = true
-
 [tool.ruff]
-# Exclude a variety of commonly ignored directories.
-exclude = [
-    "__init__.py",
-    ".bzr",
-    ".direnv",
-    ".eggs",
-    ".git",
-    ".hg",
-    ".mypy_cache",
-    ".nox",
-    ".pants.d",
-    ".ruff_cache",
-    ".svn",
-    ".tox",
-    ".venv",
-    "__pypackages__",
-    "_build",
-    "buck-out",
-    "build",
-    "dist",
-    "node_modules",
-    "venv",
-]
-
 line-length = 120
-extend-include = ["*.ipynb"]
+namespace-packages = ["src/mnt"]
 src = ["src"]
+target-version = "py311"
 
 [tool.ruff.lint]
-extend-select = [
-    "E", "F", "W", # flake8
-    "A",           # flake8-builtins
-    "B",  "B904",  # flake8-bugbear
-    "I",           # isort
-    "ARG",         # flake8-unused-arguments
-    "C4",          # flake8-comprehensions
-    "EM",          # flake8-errmsg
-    "EXE",         # flake8-executable
-    "ICN",         # flake8-import-conventions
-    "ISC",         # flake8-implicit-str-concat
-    "PGH",         # pygrep-hooks
-    "PIE",         # flake8-pie
-    "PL",          # pylint
-    "PT",          # flake8-pytest-style
-    "PTH",         # flake8-use-pathlib
-    "Q",           # flake8-quotes
-    "RET",         # flake8-return
-    "RUF",         # Ruff-specific
-    "SIM",         # flake8-simplify
-    "TCH",         # flake8-type-checking
-    "UP",          # pyupgrade
-    "YTT",         # flake8-2020
-]
-ignore = [
-    "PLR2004", # Magic values
-    "PLR0913", # Too many arguments
-    "E501",    # Line too long (Black is enough)
-]
+select = ["F", "E4", "E7", "E9", "I", "UP", "B"]

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()

--- a/src/mnt/designer/app.py
+++ b/src/mnt/designer/app.py
@@ -1,72 +1,61 @@
-import os, io, re, sys
+import argparse
+import io
+import logging
+import os
+import re
+import secrets
 import tempfile
 import uuid
-from contextlib import redirect_stdout
-import logging
 import webbrowser
+from collections.abc import Sequence
+from contextlib import redirect_stdout
+from importlib.metadata import version
+from pathlib import Path
 
-from flask import Flask, jsonify, render_template, request, send_file, session, cli
+from flask import Flask, cli, jsonify, render_template, request, send_file, session
 
 from mnt.pyfiction import (
+    a_star,
+    apply_bestagon_library,
+    apply_qca_one_library,
     cartesian_gate_layout,
     cartesian_obstruction_layout,
-    gate_level_drvs,
-    read_cartesian_fgl_layout,
-    route_path,
-    write_fgl_layout,
-    write_dot_layout,
-    read_technology_network,
-    orthogonal,
-    graph_oriented_layout_design,
-    graph_oriented_layout_design_params,
-    gold_effort_mode,
-    gold_cost_objective,
+    color_mode,
+    eq_type,
     equivalence_checking,
     equivalence_checking_stats,
-    eq_type,
+    gate_level_drvs,
+    gold_cost_objective,
+    gold_effort_mode,
+    graph_oriented_layout_design,
+    graph_oriented_layout_design_params,
+    hexagonalization,
+    orthogonal,
     post_layout_optimization,
     post_layout_optimization_params,
-    apply_qca_one_library,
-    apply_bestagon_library,
+    read_cartesian_fgl_layout,
+    read_technology_network,
+    route_path,
+    write_dot_layout,
+    write_fgl_layout,
     write_qca_layout_svg,
-    write_sqd_layout,
     write_qca_layout_svg_params,
-    hexagonalization,
-    a_star,
-    write_sidb_layout_svg_params,
     write_sidb_layout_svg,
-    color_mode,
+    write_sidb_layout_svg_params,
 )
 
 try:
-    from mnt.pyfiction import exact_params, exact_cartesian
-except ImportError:
-    # The module doesn't exist
+    from mnt.pyfiction import exact_cartesian, exact_params
+except (ImportError, AttributeError):
     exact_params = None
     exact_cartesian = None
-except AttributeError:
-    # The module exists but one or both functions are missing
-    try:
-        from mnt.pyfiction import exact_params
-    except ImportError:
-        exact_params = None
-    try:
-        from mnt.pyfiction import exact_cartesian
-    except ImportError:
-        exact_cartesian = None
 
 
-# Determine the absolute path to the directory containing this script
-current_dir = os.path.dirname(os.path.abspath(__file__))
+app = Flask(__name__)
+app.secret_key = os.environ.get("MNT_DESIGNER_SECRET_KEY") or secrets.token_hex(32)
+app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
 
-# Set the path to the static folder
-static_dir = os.path.join(current_dir, "./static")
-
-app = Flask(__name__, static_folder=static_dir)
-
-app.secret_key = "your_secret_key"  # Replace with a secure secret key
-
-# In-memory storage for user layouts
+# Layouts and networks are process-local; use a single worker for hosted instances.
 layouts = {}
 
 # In-memory storage for user networks
@@ -91,15 +80,20 @@ def create_layout():
         x = int(data.get("x")) - 1
         y = int(data.get("y")) - 1
         z = 1  # Default Z value
+        if x < 0 or y < 0:
+            return jsonify({"success": False, "error": "Layout dimensions must be positive."}), 400
 
         session_id = session["session_id"]
         layout = layouts.get(session_id)
 
+        if layout:
+            _, maximum = layout.bounding_box_2d()
+            if maximum.x > x or maximum.y > y:
+                return jsonify({"success": False, "error": "Layout dimensions would hide existing gates."}), 400
+
         if not layout:
             # Create a new layout if one doesn't exist
-            layout = cartesian_obstruction_layout(
-                cartesian_gate_layout((0, 0, 0), "2DDWave", "Layout")
-            )
+            layout = cartesian_obstruction_layout(cartesian_gate_layout((0, 0, 0), "2DDWave", "Layout"))
             layouts[session_id] = layout
 
         # Resize the existing layout
@@ -116,9 +110,9 @@ def reset_layout():
         x = int(data.get("x")) - 1
         y = int(data.get("y")) - 1
         z = 1  # Default Z value
-        layout = cartesian_obstruction_layout(
-            cartesian_gate_layout((x, y, z), "2DDWave", "Layout")
-        )
+        if x < 0 or y < 0:
+            return jsonify({"success": False, "error": "Layout dimensions must be positive."}), 400
+        layout = cartesian_obstruction_layout(cartesian_gate_layout((x, y, z), "2DDWave", "Layout"))
 
         session_id = session["session_id"]
         layouts[session_id] = layout
@@ -174,9 +168,7 @@ def place_gate():
         # Enforce incoming signal constraints
         if gate_type == "pi":
             if params:
-                return jsonify(
-                    {"success": False, "error": "PI gate cannot have inputs."}
-                )
+                return jsonify({"success": False, "error": "PI gate cannot have inputs."})
             layout.create_pi("", (x, y))
         elif gate_type in ["buf", "inv", "po"]:
             if "first" not in params or "second" in params:
@@ -200,14 +192,10 @@ def place_gate():
                     else:
                         if layout.has_northern_incoming_signal((source_x, source_y, 0)):
                             source_z = 1
-                        elif layout.has_northern_incoming_signal(
-                            (source_x, source_y, 1)
-                        ):
+                        elif layout.has_northern_incoming_signal((source_x, source_y, 1)):
                             source_z = 0
                         else:
-                            return jsonify(
-                                {"success": False, "error": "Something went wrong."}
-                            )
+                            return jsonify({"success": False, "error": "Something went wrong."})
                 elif source_y < y:
                     if layout.has_eastern_outgoing_signal((source_x, source_y, 0)):
                         source_z = 1
@@ -216,14 +204,10 @@ def place_gate():
                     else:
                         if layout.has_northern_incoming_signal((source_x, source_y, 0)):
                             source_z = 0
-                        elif layout.has_northern_incoming_signal(
-                            (source_x, source_y, 1)
-                        ):
+                        elif layout.has_northern_incoming_signal((source_x, source_y, 1)):
                             source_z = 1
                         else:
-                            return jsonify(
-                                {"success": False, "error": "Something went wrong."}
-                            )
+                            return jsonify({"success": False, "error": "Something went wrong."})
                 else:
                     return jsonify({"success": False, "error": "Something went wrong."})
 
@@ -236,14 +220,10 @@ def place_gate():
                     else:
                         if layout.has_northern_incoming_signal((source_x, source_y, 0)):
                             source_z = 0
-                        elif layout.has_northern_incoming_signal(
-                            (source_x, source_y, 1)
-                        ):
+                        elif layout.has_northern_incoming_signal((source_x, source_y, 1)):
                             source_z = 1
                         else:
-                            return jsonify(
-                                {"success": False, "error": "Something went wrong."}
-                            )
+                            return jsonify({"success": False, "error": "Something went wrong."})
                 elif source_y < y:
                     if layout.has_eastern_outgoing_signal((source_x, source_y, 0)):
                         source_z = 1
@@ -252,14 +232,10 @@ def place_gate():
                     else:
                         if layout.has_northern_incoming_signal((source_x, source_y, 0)):
                             source_z = 1
-                        elif layout.has_northern_incoming_signal(
-                            (source_x, source_y, 1)
-                        ):
+                        elif layout.has_northern_incoming_signal((source_x, source_y, 1)):
                             source_z = 0
                         else:
-                            return jsonify(
-                                {"success": False, "error": "Something went wrong."}
-                            )
+                            return jsonify({"success": False, "error": "Something went wrong."})
                 else:
                     return jsonify({"success": False, "error": "Something went wrong."})
 
@@ -328,9 +304,7 @@ def place_gate():
                         elif layout.has_northern_incoming_signal((first_x, first_y, 1)):
                             first_z = 0
                         else:
-                            return jsonify(
-                                {"success": False, "error": "Something went wrong."}
-                            )
+                            return jsonify({"success": False, "error": "Something went wrong."})
                 elif first_y < y:
                     if layout.has_eastern_outgoing_signal((first_x, first_y, 0)):
                         first_z = 1
@@ -342,9 +316,7 @@ def place_gate():
                         elif layout.has_northern_incoming_signal((first_x, first_y, 1)):
                             first_z = 1
                         else:
-                            return jsonify(
-                                {"success": False, "error": "Something went wrong."}
-                            )
+                            return jsonify({"success": False, "error": "Something went wrong."})
                 else:
                     return jsonify({"success": False, "error": "Something went wrong."})
 
@@ -360,9 +332,7 @@ def place_gate():
                         elif layout.has_northern_incoming_signal((first_x, first_y, 1)):
                             first_z = 1
                         else:
-                            return jsonify(
-                                {"success": False, "error": "Something went wrong."}
-                            )
+                            return jsonify({"success": False, "error": "Something went wrong."})
                 elif first_y < y:
                     if layout.has_eastern_outgoing_signal((first_x, first_y, 0)):
                         first_z = 1
@@ -374,9 +344,7 @@ def place_gate():
                         elif layout.has_northern_incoming_signal((first_x, first_y, 1)):
                             first_z = 0
                         else:
-                            return jsonify(
-                                {"success": False, "error": "Something went wrong."}
-                            )
+                            return jsonify({"success": False, "error": "Something went wrong."})
                 else:
                     return jsonify({"success": False, "error": "Something went wrong."})
             second_x = int(params["second"]["position"]["x"])
@@ -392,14 +360,10 @@ def place_gate():
                     else:
                         if layout.has_northern_incoming_signal((second_x, second_y, 0)):
                             second_z = 1
-                        elif layout.has_northern_incoming_signal(
-                            (second_x, second_y, 1)
-                        ):
+                        elif layout.has_northern_incoming_signal((second_x, second_y, 1)):
                             second_z = 0
                         else:
-                            return jsonify(
-                                {"success": False, "error": "Something went wrong."}
-                            )
+                            return jsonify({"success": False, "error": "Something went wrong."})
                 elif second_y < y:
                     if layout.has_eastern_outgoing_signal((second_x, second_y, 0)):
                         second_z = 1
@@ -408,18 +372,14 @@ def place_gate():
                     else:
                         if layout.has_northern_incoming_signal((second_x, second_y, 0)):
                             second_z = 0
-                        elif layout.has_northern_incoming_signal(
-                            (second_x, second_y, 1)
-                        ):
+                        elif layout.has_northern_incoming_signal((second_x, second_y, 1)):
                             second_z = 1
                         else:
-                            return jsonify(
-                                {"success": False, "error": "Something went wrong."}
-                            )
+                            return jsonify({"success": False, "error": "Something went wrong."})
                 else:
                     return jsonify({"success": False, "error": "Something went wrong."})
 
-            if first_source_gate_type == "bufk":
+            if second_source_gate_type == "bufk":
                 if second_x < x:
                     if layout.has_southern_outgoing_signal((second_x, second_y, 0)):
                         second_z = 1
@@ -428,14 +388,10 @@ def place_gate():
                     else:
                         if layout.has_northern_incoming_signal((second_x, second_y, 0)):
                             second_z = 0
-                        elif layout.has_northern_incoming_signal(
-                            (second_x, second_y, 1)
-                        ):
+                        elif layout.has_northern_incoming_signal((second_x, second_y, 1)):
                             second_z = 1
                         else:
-                            return jsonify(
-                                {"success": False, "error": "Something went wrong."}
-                            )
+                            return jsonify({"success": False, "error": "Something went wrong."})
                 elif second_y < y:
                     if layout.has_eastern_outgoing_signal((second_x, second_y, 0)):
                         second_z = 1
@@ -444,22 +400,16 @@ def place_gate():
                     else:
                         if layout.has_northern_incoming_signal((second_x, second_y, 0)):
                             second_z = 1
-                        elif layout.has_northern_incoming_signal(
-                            (second_x, second_y, 1)
-                        ):
+                        elif layout.has_northern_incoming_signal((second_x, second_y, 1)):
                             second_z = 0
                         else:
-                            return jsonify(
-                                {"success": False, "error": "Something went wrong."}
-                            )
+                            return jsonify({"success": False, "error": "Something went wrong."})
                 else:
                     return jsonify({"success": False, "error": "Something went wrong."})
             first_node = layout.get_node((first_x, first_y, first_z))
             second_node = layout.get_node((second_x, second_y, second_z))
             if not first_node or not second_node:
-                return jsonify(
-                    {"success": False, "error": "One or both source gates not found."}
-                )
+                return jsonify({"success": False, "error": "One or both source gates not found."})
 
             # Check if the gate already has inputs
             existing_fanins = layout.fanins((x, y))
@@ -511,9 +461,7 @@ def place_gate():
                 )
 
                 # Determine allowed number of fanouts
-            existing_fanouts_second_node = layout.fanouts(
-                (second_x, second_y, second_z)
-            )
+            existing_fanouts_second_node = layout.fanouts((second_x, second_y, second_z))
             num_fanouts_second_node = len(existing_fanouts_second_node)
 
             if layout.is_po(second_node):
@@ -570,9 +518,7 @@ def place_gate():
             if layout.fanout_size(second_node) == 2:
                 update_second = True
         else:
-            return jsonify(
-                {"success": False, "error": f"Unsupported gate type: {gate_type}"}
-            )
+            return jsonify({"success": False, "error": f"Unsupported gate type: {gate_type}"})
 
         layout.obstruct_coordinate((x, y, 0))
 
@@ -617,13 +563,9 @@ def delete_gate():
                     # Get the other input signals, if any
                     incoming_tiles = layout.fanins(outgoing_tile)
                     incoming_signals = [
-                        layout.make_signal(layout.get_node(inp))
-                        for inp in incoming_tiles
-                        if inp != (x, y, 1)
+                        layout.make_signal(layout.get_node(inp)) for inp in incoming_tiles if inp != (x, y, 1)
                     ]
-                    layout.move_node(
-                        layout.get_node(outgoing_tile), outgoing_tile, incoming_signals
-                    )
+                    layout.move_node(layout.get_node(outgoing_tile), outgoing_tile, incoming_signals)
         # Remove the gate from the layout
         node = layout.get_node((x, y))
         if node:
@@ -636,20 +578,12 @@ def delete_gate():
             for outgoing_tile in outgoing_tiles:
                 # Get the other input signals, if any
                 incoming_tiles = layout.fanins(outgoing_tile)
-                incoming_signals = [
-                    layout.make_signal(layout.get_node(inp))
-                    for inp in incoming_tiles
-                    if inp != (x, y)
-                ]
-                layout.move_node(
-                    layout.get_node(outgoing_tile), outgoing_tile, incoming_signals
-                )
+                incoming_signals = [layout.make_signal(layout.get_node(inp)) for inp in incoming_tiles if inp != (x, y)]
+                layout.move_node(layout.get_node(outgoing_tile), outgoing_tile, incoming_signals)
 
             return jsonify({"success": True})
         else:
-            return jsonify(
-                {"success": False, "error": "Gate not found at the specified position."}
-            )
+            return jsonify({"success": False, "error": "Gate not found at the specified position."})
     except Exception as e:
         return jsonify({"success": False, "error": str(e)})
 
@@ -875,9 +809,7 @@ def connect_gates():
             incoming_signals.append(layout.make_signal(layout.get_node(fanin)))
 
         if find_path:
-            path = a_star(
-                layout, (source_x, source_y, source_z), (target_x, target_y, target_z)
-            )
+            path = a_star(layout, (source_x, source_y, source_z), (target_x, target_y, target_z))
 
             if not path:
                 return jsonify(
@@ -892,9 +824,7 @@ def connect_gates():
         if find_path:
             route_path(layout, path)
         else:
-            layout.move_node(
-                target_node, (target_x, target_y, target_z), incoming_signals
-            )
+            layout.move_node(target_node, (target_x, target_y, target_z), incoming_signals)
 
         if layout.fanout_size(source_node) == 2:
             update = True
@@ -940,6 +870,13 @@ def move_gate():
         target_z = 0
         target = (target_x, target_y, target_z)
 
+        if not (0 <= target_x <= layout.x() and 0 <= target_y <= layout.y()):
+            return jsonify({"success": False, "error": "Target tile is outside the layout."}), 400
+        if not layout.is_empty_tile(target) or not layout.is_empty_tile((target_x, target_y, 1)):
+            return jsonify({"success": False, "error": "Target tile already has a gate."}), 400
+        if source_gate_type in ("bufc", "bufk") and layout.is_empty_tile((source_x, source_y, 0)):
+            return jsonify({"success": False, "error": "Crossing gate is incomplete."}), 400
+
         source_node = layout.get_node(source)
 
         if not source_node:
@@ -956,14 +893,8 @@ def move_gate():
         for outgoing_tile in outgoing_tiles:
             # Get the other input signals, if any
             incoming_tiles = layout.fanins(outgoing_tile)
-            incoming_signals = [
-                layout.make_signal(layout.get_node(inp))
-                for inp in incoming_tiles
-                if inp != source
-            ]
-            layout.move_node(
-                layout.get_node(outgoing_tile), outgoing_tile, incoming_signals
-            )
+            incoming_signals = [layout.make_signal(layout.get_node(inp)) for inp in incoming_tiles if inp != source]
+            layout.move_node(layout.get_node(outgoing_tile), outgoing_tile, incoming_signals)
 
         if source_gate_type in ("bufc", "bufk"):
             source_z = 0
@@ -987,14 +918,8 @@ def move_gate():
             for outgoing_tile in outgoing_tiles:
                 # Get the other input signals, if any
                 incoming_tiles = layout.fanins(outgoing_tile)
-                incoming_signals = [
-                    layout.make_signal(layout.get_node(inp))
-                    for inp in incoming_tiles
-                    if inp != source
-                ]
-                layout.move_node(
-                    layout.get_node(outgoing_tile), outgoing_tile, incoming_signals
-                )
+                incoming_signals = [layout.make_signal(layout.get_node(inp)) for inp in incoming_tiles if inp != source]
+                layout.move_node(layout.get_node(outgoing_tile), outgoing_tile, incoming_signals)
 
         return (
             jsonify(
@@ -1118,6 +1043,15 @@ def check_equivalence_function(layout, network):
     return equivalence, counter_example
 
 
+def _send_layout_file(layout, writer, filename, mimetype, *params):
+    # Each request owns its files; read the result before the temporary directory is removed.
+    with tempfile.TemporaryDirectory(prefix="mnt-designer-") as directory:
+        path = Path(directory) / filename
+        writer(layout, str(path), *params)
+        content = io.BytesIO(path.read_bytes())
+    return send_file(content, as_attachment=True, mimetype=mimetype, download_name=filename)
+
+
 @app.route("/export_layout", methods=["GET"])
 def export_layout():
     try:
@@ -1127,26 +1061,10 @@ def export_layout():
         if not layout:
             return jsonify({"success": False, "error": "Layout not found."})
 
-        # Serialize the layout to fgl file
-        output_dir = os.path.join(os.getcwd(), "exported_layouts")
-        os.makedirs(output_dir, exist_ok=True)
-        file_path = os.path.join(output_dir, "layout.fgl")
-        write_fgl_layout(layout, file_path)
-
-        # Send the fgl file as an attachment
-        return send_file(
-            file_path,
-            as_attachment=True,
-            mimetype="application/fgl",
-            download_name="layout.fgl",
-        )
+        return _send_layout_file(layout, write_fgl_layout, "layout.fgl", "application/fgl")
 
     except Exception as e:
         return jsonify({"success": False, "error": str(e)})
-    finally:
-        # Clean up the file if it exists
-        if os.path.exists(file_path):
-            os.remove(file_path)
 
 
 @app.route("/export_dot_layout", methods=["GET"])
@@ -1158,26 +1076,10 @@ def export_dot_layout():
         if not layout:
             return jsonify({"success": False, "error": "Layout not found."})
 
-        # Serialize the layout to dot file
-        output_dir = os.path.join(os.getcwd(), "exported_layouts")
-        os.makedirs(output_dir, exist_ok=True)
-        file_path = os.path.join(output_dir, "layout.dot")
-        write_dot_layout(layout, file_path)
-
-        # Send the dot file as an attachment
-        return send_file(
-            file_path,
-            as_attachment=True,
-            mimetype="application/dot",
-            download_name="layout.dot",
-        )
+        return _send_layout_file(layout, write_dot_layout, "layout.dot", "application/dot")
 
     except Exception as e:
         return jsonify({"success": False, "error": str(e)})
-    finally:
-        # Clean up the file if it exists
-        if os.path.exists(file_path):
-            os.remove(file_path)
 
 
 @app.route("/export_qca_layout", methods=["GET"])
@@ -1189,27 +1091,12 @@ def export_qca_layout():
         if not layout:
             return jsonify({"success": False, "error": "Layout not found."})
 
-        output_dir = os.path.join(os.getcwd(), "exported_layouts")
-        os.makedirs(output_dir, exist_ok=True)
-        file_path = os.path.join(output_dir, "layout_qca.svg")
-
         cell_level_layout = apply_qca_one_library(layout)
         params = write_qca_layout_svg_params()
-        write_qca_layout_svg(cell_level_layout, file_path, params)
-
-        return send_file(
-            file_path,
-            as_attachment=True,
-            mimetype="application/svg",
-            download_name="layout_qca.svg",
-        )
+        return _send_layout_file(cell_level_layout, write_qca_layout_svg, "layout_qca.svg", "image/svg+xml", params)
 
     except Exception as e:
         return jsonify({"success": False, "error": str(e)})
-    finally:
-        # Clean up the file if it exists
-        if os.path.exists(file_path):
-            os.remove(file_path)
 
 
 @app.route("/export_sidb_layout", methods=["GET"])
@@ -1224,29 +1111,12 @@ def export_sidb_layout():
         hex_layout = hexagonalization(layout)
         cell_level_layout = apply_bestagon_library(hex_layout)
 
-        output_dir = os.path.join(os.getcwd(), "exported_layouts")
-        os.makedirs(output_dir, exist_ok=True)
-        file_path = os.path.join(output_dir, "layout_sidb.svg")
-
-        write_sqd_layout(cell_level_layout, file_path)
-
         params = write_sidb_layout_svg_params()
         params.color_background = color_mode.DARK
-        write_sidb_layout_svg(cell_level_layout, file_path, params)
-
-        return send_file(
-            file_path,
-            as_attachment=True,
-            mimetype="application/svg",
-            download_name="layout_sidb.svg",
-        )
+        return _send_layout_file(cell_level_layout, write_sidb_layout_svg, "layout_sidb.svg", "image/svg+xml", params)
 
     except Exception as e:
         return jsonify({"success": False, "error": str(e)})
-    finally:
-        # Clean up the file if it exists
-        if os.path.exists(file_path):
-            os.remove(file_path)
 
 
 @app.route("/import_layout", methods=["POST"])
@@ -1257,16 +1127,10 @@ def import_layout():
         if not file:
             return jsonify({"success": False, "error": "No file provided."})
 
-        # Create a temporary file to save the uploaded fgl file
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".fgl") as temp_file:
-            file.save(temp_file.name)  # Save the uploaded file to the temporary file
-
-        # Call the function with the temporary file's name (path)
-        try:
-            layout = read_cartesian_fgl_layout(temp_file.name)
-        finally:
-            # Clean up: delete the temporary file after processing
-            os.remove(temp_file.name)
+        with tempfile.TemporaryDirectory(prefix="mnt-designer-") as directory:
+            path = Path(directory) / "layout.fgl"
+            file.save(path)
+            layout = read_cartesian_fgl_layout(str(path))
 
         # Override the current layout with the imported layout
         session_id = session["session_id"]
@@ -1288,9 +1152,7 @@ def get_layout():
 
         # Extract layout data
         layout_dimensions, gates = get_layout_information(layout)
-        return jsonify(
-            {"success": True, "layoutDimensions": layout_dimensions, "gates": gates}
-        )
+        return jsonify({"success": True, "layoutDimensions": layout_dimensions, "gates": gates})
     except Exception as e:
         return jsonify({"success": False, "error": str(e)})
 
@@ -1333,25 +1195,20 @@ def get_verilog_code():
         return jsonify({"success": False, "error": str(e)}), 500
 
 
+def _read_verilog(code):
+    with tempfile.TemporaryDirectory(prefix="mnt-designer-") as directory:
+        path = Path(directory) / "network.v"
+        path.write_text(code, encoding="utf-8")
+        return read_technology_network(str(path))
+
+
 @app.route("/save_verilog_code", methods=["POST"])
 def save_verilog_code():
     try:
         data = request.json
         code = data.get("code", "")
 
-        # Create a temporary file to save the uploaded Verilog code
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".v") as temp_file:
-            temp_file.write(code.encode("utf-8"))
-            temp_file.flush()  # Ensure all data is written to disk
-
-        # Call the function with the temporary file's name (path)
-        try:
-            network = read_technology_network(temp_file.name)
-        except Exception as e:
-            return jsonify({"success": False, "error": str(e)})
-        finally:
-            # Clean up: delete the temporary file after processing
-            os.remove(temp_file.name)
+        network = _read_verilog(code)
 
         session_id = session["session_id"]
         networks[session_id] = network
@@ -1373,17 +1230,7 @@ def import_verilog_code():
         # Read the file content
         code = uploaded_file.read().decode("utf-8")
 
-        # Create a temporary file to save the uploaded Verilog code
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".v") as temp_file:
-            temp_file.write(code.encode("utf-8"))
-            temp_file.flush()  # Ensure all data is written to disk
-
-        # Call the function with the temporary file's name (path)
-        try:
-            network = read_technology_network(temp_file.name)
-        finally:
-            # Clean up: delete the temporary file after processing
-            os.remove(temp_file.name)
+        network = _read_verilog(code)
 
         # Store the network in the session
         session_id = session["session_id"]
@@ -1442,15 +1289,11 @@ def apply_orthogonal():
         except Exception as e:
             return jsonify({"success": False, "error": str(e)})
 
-        layouts[session_id] = cartesian_obstruction_layout(
-            layout
-        )  # Update the layout in the session
+        layouts[session_id] = cartesian_obstruction_layout(layout)  # Update the layout in the session
 
         layout_dimensions, gates = get_layout_information(layout)
 
-        return jsonify(
-            {"success": True, "layoutDimensions": layout_dimensions, "gates": gates}
-        )
+        return jsonify({"success": True, "layoutDimensions": layout_dimensions, "gates": gates})
     except Exception as e:
         return jsonify({"success": False, "error": str(e)})
 
@@ -1494,27 +1337,7 @@ def apply_iosdn():
                         }
                     )
 
-        try:
-            # Apply the iosdn function
-            # layout =
-            return jsonify(
-                {
-                    "success": False,
-                    "error": "Input-ordering SDN not available in pyfiction yet.",
-                }
-            )
-        except Exception as e:
-            return jsonify({"success": False, "error": str(e)})
-
-        layouts[session_id] = cartesian_obstruction_layout(
-            layout
-        )  # Update the layout in the session
-
-        layout_dimensions, gates = get_layout_information(layout)
-
-        return jsonify(
-            {"success": True, "layoutDimensions": layout_dimensions, "gates": gates}
-        )
+        return jsonify({"success": False, "error": "Input-ordering SDN not available in pyfiction yet."})
     except Exception as e:
         return jsonify({"success": False, "error": str(e)})
 
@@ -1541,9 +1364,7 @@ def apply_gold():
             )
 
         if network.size() > 150:
-            return jsonify(
-                {"success": False, "error": "Network size exceeds 200 nodes."}
-            )
+            return jsonify({"success": False, "error": "Network size exceeds 150 nodes."})
 
         for po in network.pos():
             for fanin in network.fanins(po):
@@ -1573,6 +1394,7 @@ def apply_gold():
         params.timeout = int(data.get("timeout"))
         params.num_vertex_expansions = int(data.get("num_vertex_expansions"))
         params.planar = bool(data.get("planar"))
+        params.enable_multithreading = bool(data.get("enable_multithreading", params.enable_multithreading))
 
         cost = data.get("cost")
         if cost == "AREA":
@@ -1584,20 +1406,14 @@ def apply_gold():
         elif cost == "ACP":
             params.cost = gold_cost_objective.ACP
         else:
-            return jsonify(
-                {"success": False, "error": f"Unknown cost objective: {cost}."}
-            )
+            return jsonify({"success": False, "error": f"Unknown cost objective: {cost}."})
 
         layout = graph_oriented_layout_design(network, params)
         if layout:
-            layouts[session_id] = cartesian_obstruction_layout(
-                layout
-            )  # Update the layout in the session
+            layouts[session_id] = cartesian_obstruction_layout(layout)  # Update the layout in the session
             layout_dimensions, gates = get_layout_information(layout)
 
-            return jsonify(
-                {"success": True, "layoutDimensions": layout_dimensions, "gates": gates}
-            )
+            return jsonify({"success": True, "layoutDimensions": layout_dimensions, "gates": gates})
         else:
             return jsonify(
                 {
@@ -1631,9 +1447,7 @@ def apply_exact():
             )
 
         if network.size() > 30:
-            return jsonify(
-                {"success": False, "error": "Network size exceeds 30 nodes."}
-            )
+            return jsonify({"success": False, "error": "Network size exceeds 30 nodes."})
 
         for po in network.pos():
             for fanin in network.fanins(po):
@@ -1645,7 +1459,7 @@ def apply_exact():
                         }
                     )
 
-        if not exact_params:
+        if exact_params is None or exact_cartesian is None:
             return jsonify(
                 {
                     "success": False,
@@ -1656,8 +1470,8 @@ def apply_exact():
         data = request.json
         params = exact_params()
         params.scheme = "2DDWave"
-        params.upper_bound_x = int(data.get("upper_bound_x", sys.maxsize))
-        params.upper_bound_y = int(data.get("upper_bound_y", sys.maxsize))
+        params.upper_bound_x = int(data.get("upper_bound_x", params.upper_bound_x))
+        params.upper_bound_y = int(data.get("upper_bound_y", params.upper_bound_y))
         params.fixed_size = bool(data.get("fixed_size", False))
         params.num_threads = int(data.get("num_threads", 1))
         params.crossings = bool(data.get("crossings", True))
@@ -1673,9 +1487,7 @@ def apply_exact():
             layouts[session_id] = cartesian_obstruction_layout(layout)
             layout_dimensions, gates = get_layout_information(layout)
 
-            return jsonify(
-                {"success": True, "layoutDimensions": layout_dimensions, "gates": gates}
-            )
+            return jsonify({"success": True, "layoutDimensions": layout_dimensions, "gates": gates})
         else:
             return jsonify(
                 {
@@ -1713,9 +1525,7 @@ def apply_optimization():
         if warnings != 0:
             for x in range(layout.x() + 1):
                 for y in range(layout.y() + 1):
-                    if layout.is_dead(
-                        layout.get_node((x, y))
-                    ) and not layout.is_empty_tile((x, y)):
+                    if layout.is_dead(layout.get_node((x, y))) and not layout.is_empty_tile((x, y)):
                         return jsonify(
                             {
                                 "success": False,
@@ -1725,7 +1535,7 @@ def apply_optimization():
 
         data = request.json
         max_gate_relocations = data.get("max_gate_relocations")
-        if max_gate_relocations:
+        if max_gate_relocations is not None:
             params.max_gate_relocations = int(max_gate_relocations)
 
         params.optimize_pos_only = bool(data.get("optimize_pos_only"))
@@ -1738,9 +1548,7 @@ def apply_optimization():
 
         layout_dimensions, gates = get_layout_information(layout)
 
-        return jsonify(
-            {"success": True, "layoutDimensions": layout_dimensions, "gates": gates}
-        )
+        return jsonify({"success": True, "layoutDimensions": layout_dimensions, "gates": gates})
     except Exception as e:
         return jsonify({"success": False, "error": str(e)})
 
@@ -1758,28 +1566,33 @@ def get_layout_information(layout):
                     gate_type = "pi"
                     try:
                         name = layout.get_name(layout.make_signal(node))
-                    except:
+                    except Exception:
                         name = ""
                 elif layout.is_po(node):
                     gate_type = "po"
                     try:
                         name = layout.get_name(layout.make_signal(node))
-                    except:
+                    except Exception:
                         name = ""
                 elif layout.is_wire(node):
                     gate_type = "buf"
                     above_gate = layout.above(layout.get_tile(node))
                     if not layout.is_empty_tile(above_gate) and layout.z() == 1:
+                        incoming = layout.fanins(above_gate)
+                        outgoing = layout.fanouts(above_gate)
                         if (
-                            layout.fanins(above_gate)[0].x
-                            == layout.west(layout.get_tile(node)).x
-                            and layout.fanouts(above_gate)[0].x
-                            == layout.east(layout.get_tile(node)).x
-                        ) or (
-                            layout.fanins(above_gate)[0].x
-                            == layout.north(layout.get_tile(node)).x
-                            and layout.fanouts(above_gate)[0].x
-                            == layout.south(layout.get_tile(node)).x
+                            incoming
+                            and outgoing
+                            and (
+                                (
+                                    incoming[0].x == layout.west(layout.get_tile(node)).x
+                                    and outgoing[0].x == layout.east(layout.get_tile(node)).x
+                                )
+                                or (
+                                    incoming[0].x == layout.north(layout.get_tile(node)).x
+                                    and outgoing[0].x == layout.south(layout.get_tile(node)).x
+                                )
+                            )
                         ):
                             gate_type = "bufc"
                         else:
@@ -1813,31 +1626,39 @@ def get_layout_information(layout):
                 # Get fanins (source nodes)
                 fanins = layout.fanins((x, y))
                 for fin in fanins:
-                    gate_info["connections"].append(
-                        {"sourceX": fin.x, "sourceY": fin.y}
-                    )
+                    gate_info["connections"].append({"sourceX": fin.x, "sourceY": fin.y})
                 if gate_type in ("bufc", "bufk"):
                     fanins = layout.fanins((x, y, 1))
                     for fin in fanins:
-                        gate_info["connections"].append(
-                            {"sourceX": fin.x, "sourceY": fin.y}
-                        )
+                        gate_info["connections"].append({"sourceX": fin.x, "sourceY": fin.y})
                 gates.append(gate_info)
     return layout_dimensions, gates
 
 
-def start_server():
+def start_server(host: str = "127.0.0.1", port: int = 5001, open_browser: bool = True) -> None:
     logging.getLogger("werkzeug").setLevel(logging.ERROR)
+    url = f"http://{host}:{port}"
     print(
-        "Server is hosted at: http://127.0.0.1:5001.",
+        f"Server is hosted at: {url}.",
         "To stop it, interrupt the process (e.g., via CTRL+C). \n",
     )
     cli.show_server_banner = lambda *_args: None
-    # Automatically open the default browser
-    url = "http://127.0.0.1:5001"
-    webbrowser.open(url)
-    app.run(debug=False, port=5001)
+    if open_browser:
+        webbrowser.open(url)
+    app.run(debug=False, host=host, port=port)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Start the MNT Designer web interface.")
+    parser.add_argument("--host", default="127.0.0.1", help="Address to bind to (default: 127.0.0.1).")
+    parser.add_argument("--port", type=int, default=5001, help="Port to listen on (default: 5001).")
+    parser.add_argument("--no-browser", action="store_true", help="Do not open a browser automatically.")
+    parser.add_argument("--version", action="version", version=f"%(prog)s {version('mnt.designer')}")
+    args = parser.parse_args(argv)
+    if not 1 <= args.port <= 65535:
+        parser.error("--port must be between 1 and 65535")
+    start_server(host=args.host, port=args.port, open_browser=not args.no_browser)
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    main()

--- a/src/mnt/designer/app.py
+++ b/src/mnt/designer/app.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import secrets
+import struct
 import tempfile
 import uuid
 import webbrowser
@@ -521,8 +522,11 @@ def place_gate():
                     (x, y),
                 )
             elif gate_type in ["bufc", "bufk"]:
-                layout.create_buf(layout.make_signal(first_node), (x, y, 0))
-                layout.create_buf(layout.make_signal(second_node), (x, y, 1))
+                # The upper wire always faces east: west input for straight, north input for bent crossings.
+                upper_is_first = first_x < x if gate_type == "bufc" else first_y < y
+                lower_node, upper_node = (second_node, first_node) if upper_is_first else (first_node, second_node)
+                layout.create_buf(layout.make_signal(lower_node), (x, y, 0))
+                layout.create_buf(layout.make_signal(upper_node), (x, y, 1))
                 layout.obstruct_coordinate((x, y, 1))
             if layout.fanout_size(first_node) == 2:
                 update_first = True
@@ -884,12 +888,12 @@ def move_gate():
         source = (source_x, source_y, source_z)
         target_x = int(data["target_x"])
         target_y = int(data["target_y"])
-        target_z = 0
+        target_z = source_z
         target = (target_x, target_y, target_z)
 
         if not (0 <= target_x <= layout.x() and 0 <= target_y <= layout.y()):
             return jsonify({"success": False, "error": "Target tile is outside the layout."}), 400
-        if not layout.is_empty_tile(target) or not layout.is_empty_tile((target_x, target_y, 1)):
+        if not layout.is_empty_tile((target_x, target_y, 0)) or not layout.is_empty_tile((target_x, target_y, 1)):
             return jsonify({"success": False, "error": "Target tile already has a gate."}), 400
         if source_gate_type in ("bufc", "bufk") and layout.is_empty_tile((source_x, source_y, 0)):
             return jsonify({"success": False, "error": "Crossing gate is incomplete."}), 400
@@ -916,7 +920,7 @@ def move_gate():
         if source_gate_type in ("bufc", "bufk"):
             source_z = 0
             source = (source_x, source_y, source_z)
-            target_z = 1
+            target_z = 0
             target = (target_x, target_y, target_z)
 
             source_node = layout.get_node(source)
@@ -1495,19 +1499,29 @@ def apply_exact():
             )
         # Parameters
         data = request.json
+        if not isinstance(data, dict):
+            return jsonify({"success": False, "error": "Exact parameters must be a JSON object."}), 400
         params = exact_params()
         params.scheme = "2DDWave"
-        params.upper_bound_x = int(data.get("upper_bound_x", params.upper_bound_x))
-        params.upper_bound_y = int(data.get("upper_bound_y", params.upper_bound_y))
+        # Match the native uint16_t bounds, size_t thread count, and unsigned timeout.
+        limits = {
+            "upper_bound_x": 65535,
+            "upper_bound_y": 65535,
+            "num_threads": (1 << (8 * struct.calcsize("P"))) - 1,
+            "timeout": 4294967295,
+        }
+        for name, maximum in limits.items():
+            value = data.get(name, getattr(params, name))
+            if type(value) is not int or not 1 <= value <= maximum:
+                return jsonify({"success": False, "error": f"{name} must be an integer between 1 and {maximum}."}), 400
+            setattr(params, name, value)
         params.fixed_size = bool(data.get("fixed_size", False))
-        params.num_threads = int(data.get("num_threads", 1))
         params.crossings = bool(data.get("crossings", True))
         params.border_io = bool(data.get("border_io", True))
         params.straight_inverters = bool(data.get("straight_inverters", False))
         params.desynchronize = bool(data.get("desynchronize", True))
         params.minimize_wires = bool(data.get("minimize_wires", False))
         params.minimize_crossings = bool(data.get("minimize_crossings", False))
-        params.timeout = int(data.get("timeout", 4294967))
         # Now run the exact algorithm
         layout = exact_cartesian(network, params)
         if layout:
@@ -1584,6 +1598,25 @@ def apply_optimization():
         return jsonify({"success": False, "error": str(e)})
 
 
+def _crossing_type(layout, x, y):
+    # Connected native/FGL layouts may use either layer order; actual wiring takes precedence.
+    for z in (0, 1):
+        incoming = layout.fanins((x, y, z))
+        outgoing = layout.fanouts((x, y, z))
+        if incoming and outgoing:
+            return "bufc" if incoming[0].x == outgoing[0].x or incoming[0].y == outgoing[0].y else "bufk"
+
+    # Input-only crossings created here encode intent in their east-facing upper wire.
+    for z in (1, 0):
+        incoming = layout.fanins((x, y, z))
+        if incoming:
+            straight = incoming[0].x < x if z == 1 else incoming[0].y < y
+            return "bufc" if straight else "bufk"
+    # Fully disconnected crossings have no routing intent in native/FGL data. Foreign partial
+    # layouts may also use a different layer convention; their original intent cannot be recovered.
+    return "bufk"
+
+
 def get_layout_information(layout):
     layout_dimensions = {"x": layout.x() + 1, "y": layout.y() + 1}
     gates = []
@@ -1609,25 +1642,7 @@ def get_layout_information(layout):
                     gate_type = "buf"
                     above_gate = layout.above(layout.get_tile(node))
                     if not layout.is_empty_tile(above_gate) and layout.z() == 1:
-                        incoming = layout.fanins(above_gate)
-                        outgoing = layout.fanouts(above_gate)
-                        if (
-                            incoming
-                            and outgoing
-                            and (
-                                (
-                                    incoming[0].x == layout.west(layout.get_tile(node)).x
-                                    and outgoing[0].x == layout.east(layout.get_tile(node)).x
-                                )
-                                or (
-                                    incoming[0].x == layout.north(layout.get_tile(node)).x
-                                    and outgoing[0].x == layout.south(layout.get_tile(node)).x
-                                )
-                            )
-                        ):
-                            gate_type = "bufc"
-                        else:
-                            gate_type = "bufk"
+                        gate_type = _crossing_type(layout, x, y)
                     if layout.fanout_size(node) == 2:
                         gate_type = "fanout"
                 elif layout.is_inv(node):

--- a/src/mnt/designer/app.py
+++ b/src/mnt/designer/app.py
@@ -13,6 +13,7 @@ from importlib.metadata import version
 from pathlib import Path
 
 from flask import Flask, cli, jsonify, render_template, request, send_file, session
+from werkzeug.exceptions import RequestEntityTooLarge
 
 from mnt.pyfiction import (
     a_star,
@@ -54,6 +55,7 @@ except (ImportError, AttributeError):
 app = Flask(__name__)
 app.secret_key = os.environ.get("MNT_DESIGNER_SECRET_KEY") or secrets.token_hex(32)
 app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+app.config["MAX_CONTENT_LENGTH"] = 5 * 1024 * 1024  # Entire request, including multipart overhead.
 
 # Layouts and networks are process-local; use a single worker for hosted instances.
 layouts = {}
@@ -63,6 +65,11 @@ networks = {}
 
 # In-memory storage for user verilog
 verilogs = {}
+
+
+@app.errorhandler(RequestEntityTooLarge)
+def request_too_large(_error):
+    return jsonify({"success": False, "error": "Request exceeds the upload size limit."}), 413
 
 
 @app.route("/")
@@ -99,6 +106,8 @@ def create_layout():
         # Resize the existing layout
         layout.resize((x, y, z))
         return jsonify({"success": True})
+    except RequestEntityTooLarge:
+        raise
     except Exception as e:
         return jsonify({"success": False, "error": str(e)})
 
@@ -118,6 +127,8 @@ def reset_layout():
         layouts[session_id] = layout
 
         return jsonify({"success": True})
+    except RequestEntityTooLarge:
+        raise
     except Exception as e:
         return jsonify({"success": False, "error": str(e)})
 
@@ -533,6 +544,8 @@ def place_gate():
             200,
         )
 
+    except RequestEntityTooLarge:
+        raise
     except Exception as e:
         print(f"Error in place_gate: {e}")
         return jsonify({"success": False, "error": str(e)})
@@ -584,6 +597,8 @@ def delete_gate():
             return jsonify({"success": True})
         else:
             return jsonify({"success": False, "error": "Gate not found at the specified position."})
+    except RequestEntityTooLarge:
+        raise
     except Exception as e:
         return jsonify({"success": False, "error": str(e)})
 
@@ -847,6 +862,8 @@ def connect_gates():
             ),
             200,
         )
+    except RequestEntityTooLarge:
+        raise
     except Exception as e:
         return jsonify({"success": False, "error": str(e)})
 
@@ -930,6 +947,8 @@ def move_gate():
             ),
             200,
         )
+    except RequestEntityTooLarge:
+        raise
     except Exception as e:
         return jsonify({"success": False, "error": str(e)})
 
@@ -1138,6 +1157,8 @@ def import_layout():
 
         return jsonify({"success": True})
 
+    except RequestEntityTooLarge:
+        raise
     except Exception as e:
         return jsonify({"success": False, "error": str(e)})
 
@@ -1215,6 +1236,8 @@ def save_verilog_code():
         verilogs[session_id] = code
 
         return jsonify({"success": True})
+    except RequestEntityTooLarge:
+        raise
     except Exception as e:
         return jsonify({"success": False, "error": str(e)})
 
@@ -1240,6 +1263,8 @@ def import_verilog_code():
         # Return the code to be displayed in the editor
         return jsonify({"success": True, "code": code})
 
+    except RequestEntityTooLarge:
+        raise
     except Exception as e:
         return jsonify({"success": False, "error": str(e)})
 
@@ -1421,6 +1446,8 @@ def apply_gold():
                     "error": "No layout found with the specified parameters.",
                 }
             )
+    except RequestEntityTooLarge:
+        raise
     except Exception as e:
         return jsonify({"success": False, "error": str(e)})
 
@@ -1495,6 +1522,8 @@ def apply_exact():
                     "error": "No layout found with the specified parameters.",
                 }
             )
+    except RequestEntityTooLarge:
+        raise
     except Exception as e:
         return jsonify({"success": False, "error": str(e)})
 
@@ -1549,6 +1578,8 @@ def apply_optimization():
         layout_dimensions, gates = get_layout_information(layout)
 
         return jsonify({"success": True, "layoutDimensions": layout_dimensions, "gates": gates})
+    except RequestEntityTooLarge:
+        raise
     except Exception as e:
         return jsonify({"success": False, "error": str(e)})
 

--- a/src/mnt/designer/app.py
+++ b/src/mnt/designer/app.py
@@ -154,6 +154,11 @@ def reset_editor():
         return jsonify({"success": False, "error": str(e)}), 500
 
 
+def _gate_layer(layout, x, y):
+    # The editor projects both native layers onto one tile; an isolated upper wire is still editable.
+    return 1 if layout.z() > 0 and layout.is_empty_tile((x, y, 0)) else 0
+
+
 @app.route("/place_gate", methods=["POST"])
 def place_gate():
     try:
@@ -170,7 +175,7 @@ def place_gate():
         if not layout:
             return jsonify({"success": False, "error": "Layout not found."})
 
-        node = layout.get_node((x, y))
+        node = layout.get_node((x, y, _gate_layer(layout, x, y)))
         if node != 0:
             return jsonify({"success": False, "error": "Tile already has a gate."})
 
@@ -192,7 +197,7 @@ def place_gate():
                 )
             source_x = int(params["first"]["position"]["x"])
             source_y = int(params["first"]["position"]["y"])
-            source_z = 0
+            source_z = _gate_layer(layout, source_x, source_y)
             source_gate_type = params["first"]["gate_type"]
 
             if source_gate_type == "bufc":
@@ -302,7 +307,7 @@ def place_gate():
                 )
             first_x = int(params["first"]["position"]["x"])
             first_y = int(params["first"]["position"]["y"])
-            first_z = 0
+            first_z = _gate_layer(layout, first_x, first_y)
             first_source_gate_type = params["first"]["gate_type"]
             if first_source_gate_type == "bufc":
                 if first_x < x:
@@ -361,7 +366,7 @@ def place_gate():
                     return jsonify({"success": False, "error": "Something went wrong."})
             second_x = int(params["second"]["position"]["x"])
             second_y = int(params["second"]["position"]["y"])
-            second_z = 0
+            second_z = _gate_layer(layout, second_x, second_y)
             second_source_gate_type = params["second"]["gate_type"]
             if second_source_gate_type == "bufc":
                 if second_x < x:
@@ -567,37 +572,21 @@ def delete_gate():
         if not layout:
             return jsonify({"success": False, "error": "Layout not found."})
 
-        if not layout.is_empty_tile((x, y, 1)):
-            node = layout.get_node((x, y, 1))
-            if node:
-                # Find all gates that use this node as an input signal
-                outgoing_tiles = layout.fanouts((x, y, 1))
-                layout.clear_tile((x, y, 1))
-                layout.clear_obstructed_coordinate((x, y, 1))
-
-                # Update signals for dependent nodes
-                for outgoing_tile in outgoing_tiles:
-                    # Get the other input signals, if any
-                    incoming_tiles = layout.fanins(outgoing_tile)
-                    incoming_signals = [
-                        layout.make_signal(layout.get_node(inp)) for inp in incoming_tiles if inp != (x, y, 1)
-                    ]
-                    layout.move_node(layout.get_node(outgoing_tile), outgoing_tile, incoming_signals)
-        # Remove the gate from the layout
-        node = layout.get_node((x, y))
-        if node:
-            # Find all gates that use this node as an input signal
-            outgoing_tiles = layout.fanouts((x, y))
-            layout.clear_tile((x, y))
-            layout.clear_obstructed_coordinate((x, y))
-
-            # Update signals for dependent nodes
+        found = False
+        for z in (1, 0) if layout.z() > 0 else (0,):
+            tile = (x, y, z)
+            if layout.is_empty_tile(tile):
+                continue
+            found = True
+            outgoing_tiles = layout.fanouts(tile)
+            layout.clear_tile(tile)
+            layout.clear_obstructed_coordinate(tile)
             for outgoing_tile in outgoing_tiles:
-                # Get the other input signals, if any
                 incoming_tiles = layout.fanins(outgoing_tile)
-                incoming_signals = [layout.make_signal(layout.get_node(inp)) for inp in incoming_tiles if inp != (x, y)]
+                incoming_signals = [layout.make_signal(layout.get_node(inp)) for inp in incoming_tiles if inp != tile]
                 layout.move_node(layout.get_node(outgoing_tile), outgoing_tile, incoming_signals)
 
+        if found:
             return jsonify({"success": True})
         else:
             return jsonify({"success": False, "error": "Gate not found at the specified position."})
@@ -618,11 +607,11 @@ def connect_gates():
 
         source_x = int(data["source_x"])
         source_y = int(data["source_y"])
-        source_z = 0
+        source_z = _gate_layer(layout, source_x, source_y)
         source_gate_type = data["source_gate_type"]
         target_x = int(data["target_x"])
         target_y = int(data["target_y"])
-        target_z = 0
+        target_z = _gate_layer(layout, target_x, target_y)
         target_gate_type = data["target_gate_type"]
         find_path = data["find_path"]
 
@@ -884,7 +873,7 @@ def move_gate():
         source_x = int(data["source_x"])
         source_y = int(data["source_y"])
         source_gate_type = data["source_gate_type"]
-        source_z = 0 if source_gate_type not in ("bufc", "bufk") else 1
+        source_z = _gate_layer(layout, source_x, source_y) if source_gate_type not in ("bufc", "bufk") else 1
         source = (source_x, source_y, source_z)
         target_x = int(data["target_x"])
         target_y = int(data["target_y"])
@@ -1568,13 +1557,14 @@ def apply_optimization():
         if warnings != 0:
             for x in range(layout.x() + 1):
                 for y in range(layout.y() + 1):
-                    if layout.is_dead(layout.get_node((x, y))) and not layout.is_empty_tile((x, y)):
-                        return jsonify(
-                            {
-                                "success": False,
-                                "error": f"Layout has a dead node: ({x}, {y}). Fix it first before optimizing.",
-                            }
-                        )
+                    for z in range(layout.z() + 1):
+                        if not layout.is_empty_tile((x, y, z)) and layout.is_dead(layout.get_node((x, y, z))):
+                            return jsonify(
+                                {
+                                    "success": False,
+                                    "error": f"Layout has a dead node: ({x}, {y}, {z}). Fix it first before optimizing.",
+                                }
+                            )
 
         data = request.json
         max_gate_relocations = data.get("max_gate_relocations")
@@ -1623,7 +1613,8 @@ def get_layout_information(layout):
 
     for x in range(layout.x() + 1):
         for y in range(layout.y() + 1):
-            node = layout.get_node((x, y))
+            z = _gate_layer(layout, x, y)
+            node = layout.get_node((x, y, z))
             name = ""
             if node:
                 if layout.is_pi(node):
@@ -1641,7 +1632,7 @@ def get_layout_information(layout):
                 elif layout.is_wire(node):
                     gate_type = "buf"
                     above_gate = layout.above(layout.get_tile(node))
-                    if not layout.is_empty_tile(above_gate) and layout.z() == 1:
+                    if z == 0 and layout.z() == 1 and not layout.is_empty_tile(above_gate):
                         gate_type = _crossing_type(layout, x, y)
                     if layout.fanout_size(node) == 2:
                         gate_type = "fanout"
@@ -1670,7 +1661,7 @@ def get_layout_information(layout):
                     "name": name,
                 }
                 # Get fanins (source nodes)
-                fanins = layout.fanins((x, y))
+                fanins = layout.fanins((x, y, z))
                 for fin in fanins:
                     gate_info["connections"].append({"sourceX": fin.x, "sourceY": fin.y})
                 if gate_type in ("bufc", "bufk"):

--- a/src/mnt/designer/app.py
+++ b/src/mnt/designer/app.py
@@ -1668,7 +1668,8 @@ def get_layout_information(layout):
 
 def start_server(host: str = "127.0.0.1", port: int = 5001, open_browser: bool = True) -> None:
     logging.getLogger("werkzeug").setLevel(logging.ERROR)
-    url = f"http://{host}:{port}"
+    url_host = f"[{host}]" if ":" in host else host
+    url = f"http://{url_host}:{port}"
     print(
         f"Server is hosted at: {url}.",
         "To stop it, interrupt the process (e.g., via CTRL+C). \n",

--- a/src/mnt/designer/static/js/script.js
+++ b/src/mnt/designer/static/js/script.js
@@ -50,8 +50,9 @@ $(document).ready(() => {
           }
         },
         error: function (jqXHR, textStatus, errorThrown) {
+          valid_verilog = false;
           updateMessageArea(
-            "Error communicating with the server: " + errorThrown,
+            "Failed to save verilog: " + (jqXHR.responseJSON?.error || errorThrown),
             "danger",
           );
         },
@@ -669,7 +670,7 @@ $(document).ready(() => {
         error: (jqXHR, textStatus, errorThrown) => {
           $("#import-verilog-button").prop("disabled", false); // Re-enable button
           updateMessageArea(
-            "Error communicating with the server: " + errorThrown,
+            "Failed to import Verilog code: " + (jqXHR.responseJSON?.error || errorThrown),
             "danger",
           );
         },
@@ -2259,7 +2260,7 @@ $(document).ready(() => {
         error: (jqXHR, textStatus, errorThrown) => {
           $("#import-button").prop("disabled", false); // Re-enable button
           updateMessageArea(
-            "Error communicating with the server: " + errorThrown,
+            "Failed to import layout: " + (jqXHR.responseJSON?.error || errorThrown),
             "danger",
           );
         },

--- a/tests/test_designer.py
+++ b/tests/test_designer.py
@@ -238,3 +238,15 @@ def test_cli(monkeypatch, capsys):
     monkeypatch.setattr(designer, "start_server", lambda **kwargs: calls.append(kwargs))
     designer.main(["--host", "127.0.0.1", "--port", "5053", "--no-browser"])
     assert calls == [{"host": "127.0.0.1", "port": 5053, "open_browser": False}]
+
+
+@pytest.mark.parametrize("host,url_host", [("127.0.0.1", "127.0.0.1"), ("localhost", "localhost"), ("::1", "[::1]")])
+def test_cli_browser_url_preserves_bind_host(monkeypatch, capsys, host, url_host):
+    opened = []
+    calls = []
+    monkeypatch.setattr(designer.webbrowser, "open", opened.append)
+    monkeypatch.setattr(designer.app, "run", lambda **kwargs: calls.append(kwargs))
+    designer.main(["--host", host, "--port", "5053"])
+    assert opened == [f"http://{url_host}:5053"]
+    assert opened[0] in capsys.readouterr().out
+    assert calls == [{"debug": False, "host": host, "port": 5053}]

--- a/tests/test_designer.py
+++ b/tests/test_designer.py
@@ -1,0 +1,204 @@
+"""Small end-to-end checks against the installed pyfiction bindings."""
+
+import io
+from importlib.metadata import version
+from xml.etree import ElementTree
+
+import pytest
+
+from mnt.designer import app as designer
+
+VERILOG = """module top(a, b, y);
+input a, b;
+output y;
+assign y = a & b;
+endmodule
+"""
+EXPORTS = {
+    "/export_layout": "layout.fgl",
+    "/export_dot_layout": "layout.dot",
+    "/export_qca_layout": "layout_qca.svg",
+    "/export_sidb_layout": "layout_sidb.svg",
+}
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setitem(designer.app.config, "TESTING", True)
+    for name in ("layouts", "networks", "verilogs"):
+        monkeypatch.setattr(designer, name, {})
+    with designer.app.test_client() as client:
+        assert client.get("/").status_code == 200
+        yield client
+
+
+def post(client, route, payload=None, *, success=True):
+    response = client.post(route, json=payload or {})
+    assert response.is_json, response.get_data(as_text=True)
+    result = response.get_json()
+    assert result["success"] is success, result
+    return result
+
+
+@pytest.fixture
+def placed(client):
+    post(client, "/save_verilog_code", {"code": VERILOG})
+    post(client, "/apply_orthogonal")
+    return client
+
+
+def test_design_workflow(placed):
+    layout = placed.get("/get_layout").get_json()
+    assert layout["success"]
+    assert {gate["type"] for gate in layout["gates"]} >= {"pi", "and", "po"}
+    assert placed.get("/get_verilog_code").get_json()["code"] == VERILOG
+    assert post(placed, "/check_design_rules")["errors"] == 0
+    assert post(placed, "/check_equivalence")["equivalence"] in {"STRONG", "WEAK"}
+    optimized = post(
+        placed,
+        "/apply_optimization",
+        {"timeout": 1000, "max_gate_relocations": 1, "optimize_pos_only": False, "planar_optimization": True},
+    )
+    assert optimized["gates"]
+    assert post(placed, "/check_equivalence")["equivalence"] in {"STRONG", "WEAK"}
+
+
+def test_exports_and_fgl_roundtrip(placed, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    original = placed.get("/get_layout").get_json()
+    exports = {}
+    for route, filename in EXPORTS.items():
+        response = placed.get(route)
+        assert response.status_code == 200
+        assert filename in response.headers["Content-Disposition"]
+        assert response.data
+        exports[route] = response.data
+        if filename.endswith(".svg"):
+            assert response.mimetype == "image/svg+xml"
+            assert ElementTree.fromstring(response.data).tag.endswith("svg")
+    assert not list(tmp_path.iterdir())
+    post(placed, "/reset_layout", {"x": 2, "y": 2})
+    imported = placed.post("/import_layout", data={"file": (io.BytesIO(exports["/export_layout"]), "example.fgl")})
+    assert imported.get_json()["success"]
+    assert placed.get("/get_layout").get_json() == original
+
+
+def test_missing_layout_exports_and_session_isolation(placed):
+    other = designer.app.test_client()
+    assert other.get("/").status_code == 200
+    for route in EXPORTS:
+        response = other.get(route)
+        assert response.status_code < 500
+        assert response.is_json and response.get_json()["success"] is False
+    assert other.get("/get_verilog_code").get_json()["success"] is False
+    post(other, "/reset_layout", {"x": 2, "y": 3})
+    assert other.get("/get_layout").get_json()["gates"] == []
+    assert placed.get("/get_layout").get_json()["gates"]
+    assert designer.app.secret_key != "your_secret_key"
+
+
+def test_import_verilog_and_safe_layout_edits(client):
+    imported = client.post("/import_verilog_code", data={"file": (io.BytesIO(VERILOG.encode()), "example.v")})
+    assert imported.get_json() == {"success": True, "code": VERILOG}
+    post(client, "/create_layout", {"x": 3, "y": 3})
+    for x, y in ((0, 0), (2, 2)):
+        post(client, "/place_gate", {"x": x, "y": y, "gate_type": "pi", "params": {}})
+    original = client.get("/get_layout").get_json()
+    post(client, "/create_layout", {"x": 2, "y": 2}, success=False)
+    for route in ("/create_layout", "/reset_layout"):
+        post(client, route, {"x": 0, "y": 3}, success=False)
+    post(
+        client,
+        "/move_gate",
+        {"source_x": 0, "source_y": 0, "source_gate_type": "pi", "target_x": 2, "target_y": 2},
+        success=False,
+    )
+    assert client.get("/get_layout").get_json() == original
+    post(
+        client,
+        "/move_gate",
+        {"source_x": 0, "source_y": 0, "source_gate_type": "pi", "target_x": 1, "target_y": 0},
+    )
+    post(client, "/delete_gate", {"x": 1, "y": 0})
+    assert len(client.get("/get_layout").get_json()["gates"]) == 1
+
+
+def test_disconnected_crossing_remains_readable(client):
+    post(client, "/create_layout", {"x": 3, "y": 3})
+    for x, y in ((0, 1), (1, 0)):
+        post(client, "/place_gate", {"x": x, "y": y, "gate_type": "pi", "params": {}})
+    post(
+        client,
+        "/place_gate",
+        {
+            "x": 1,
+            "y": 1,
+            "gate_type": "bufc",
+            "params": {
+                "first": {"position": {"x": 0, "y": 1}, "gate_type": "pi"},
+                "second": {"position": {"x": 1, "y": 0}, "gate_type": "pi"},
+            },
+        },
+    )
+    result = client.get("/get_layout").get_json()
+    assert result["success"] and len(result["gates"]) == 3
+
+
+@pytest.mark.parametrize("multithreading", [False, True])
+def test_gold_forwards_multithreading(placed, monkeypatch, multithreading):
+    run_gold = designer.graph_oriented_layout_design
+
+    def capture(network, params):
+        assert params.enable_multithreading is multithreading
+        return run_gold(network, params)
+
+    monkeypatch.setattr(designer, "graph_oriented_layout_design", capture)
+    result = post(
+        placed,
+        "/apply_gold",
+        {
+            "return_first": True,
+            "mode": "HIGH_EFFICIENCY",
+            "timeout": 1000,
+            "num_vertex_expansions": 1,
+            "planar": True,
+            "cost": "AREA",
+            "enable_multithreading": multithreading,
+        },
+    )
+    assert result["gates"]
+
+
+def test_zero_relocations_is_forwarded(placed, monkeypatch):
+    def capture(layout, params):
+        assert params.max_gate_relocations == 0
+
+    monkeypatch.setattr(designer, "post_layout_optimization", capture)
+    post(placed, "/apply_optimization", {"timeout": 1000, "max_gate_relocations": 0})
+
+
+def test_exact_defaults_and_unavailable_solver(placed, monkeypatch):
+    if designer.exact_params is not None:
+        defaults = designer.exact_params()
+
+        def capture(network, params):
+            assert params.upper_bound_x == defaults.upper_bound_x
+            assert params.upper_bound_y == defaults.upper_bound_y
+            return designer.orthogonal(network)
+
+        monkeypatch.setattr(designer, "exact_cartesian", capture)
+        assert post(placed, "/apply_exact", {"timeout": 1000})["gates"]
+    monkeypatch.setattr(designer, "exact_params", None)
+    monkeypatch.setattr(designer, "exact_cartesian", None)
+    assert "Z3" in post(placed, "/apply_exact", success=False)["error"]
+
+
+def test_cli(monkeypatch, capsys):
+    with pytest.raises(SystemExit) as exc:
+        designer.main(["--version"])
+    assert exc.value.code == 0
+    assert version("mnt.designer") in capsys.readouterr().out
+    calls = []
+    monkeypatch.setattr(designer, "start_server", lambda **kwargs: calls.append(kwargs))
+    designer.main(["--host", "127.0.0.1", "--port", "5053", "--no-browser"])
+    assert calls == [{"host": "127.0.0.1", "port": 5053, "open_browser": False}]

--- a/tests/test_designer.py
+++ b/tests/test_designer.py
@@ -1,6 +1,7 @@
 """Small end-to-end checks against the installed pyfiction bindings."""
 
 import io
+import struct
 from importlib.metadata import version
 from xml.etree import ElementTree
 
@@ -159,25 +160,114 @@ def test_import_verilog_and_safe_layout_edits(client):
     assert len(client.get("/get_layout").get_json()["gates"]) == 1
 
 
-def test_disconnected_crossing_remains_readable(client):
-    post(client, "/create_layout", {"x": 3, "y": 3})
-    for x, y in ((0, 1), (1, 0)):
+@pytest.mark.parametrize("gate_type", ["bufc", "bufk"])
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("consumer", ["po", "and"])
+def test_partial_crossing_roundtrip_preserves_routing(client, gate_type, reverse, consumer):
+    post(client, "/create_layout", {"x": 4, "y": 4})
+    inputs = [(0, 1), (1, 0)]
+    for x, y in inputs:
         post(client, "/place_gate", {"x": x, "y": y, "gate_type": "pi", "params": {}})
+    if reverse:
+        inputs.reverse()
     post(
         client,
         "/place_gate",
         {
             "x": 1,
             "y": 1,
-            "gate_type": "bufc",
+            "gate_type": gate_type,
             "params": {
-                "first": {"position": {"x": 0, "y": 1}, "gate_type": "pi"},
-                "second": {"position": {"x": 1, "y": 0}, "gate_type": "pi"},
+                key: {"position": {"x": x, "y": y}, "gate_type": "pi"}
+                for key, (x, y) in zip(("first", "second"), inputs, strict=True)
             },
         },
     )
-    result = client.get("/get_layout").get_json()
-    assert result["success"] and len(result["gates"]) == 3
+
+    def crossing_type():
+        gates = client.get("/get_layout").get_json()["gates"]
+        return next(gate["type"] for gate in gates if (gate["x"], gate["y"]) == (1, 1))
+
+    def import_fgl(content):
+        post(client, "/reset_layout", {"x": 1, "y": 1})
+        response = client.post("/import_layout", data={"file": (io.BytesIO(content), "crossing.fgl")})
+        assert response.get_json()["success"], response.get_json()
+        assert crossing_type() == gate_type
+
+    assert crossing_type() == gate_type
+    assert client.get("/").status_code == 200  # Reload before either output exists.
+    assert crossing_type() == gate_type
+
+    for index, (x, y) in enumerate(((2, 1), (1, 2))):
+        params = {"first": {"position": {"x": 1, "y": 1}, "gate_type": crossing_type()}}
+        if consumer == "and":
+            aux_x, aux_y = (2, 0) if index == 0 else (0, 2)
+            post(client, "/place_gate", {"x": aux_x, "y": aux_y, "gate_type": "pi", "params": {}})
+            params["second"] = {"position": {"x": aux_x, "y": aux_y}, "gate_type": "pi"}
+            if index == 1:  # Crossing consumers must work in either input slot.
+                params["first"], params["second"] = params["second"], params["first"]
+        post(client, "/place_gate", {"x": x, "y": y, "gate_type": consumer, "params": params})
+        assert crossing_type() == gate_type  # Also check the one-output state.
+        if consumer == "and":
+            post(
+                client,
+                "/place_gate",
+                {
+                    "x": 3 if index == 0 else 1,
+                    "y": 1 if index == 0 else 3,
+                    "gate_type": "po",
+                    "params": {"first": {"position": {"x": x, "y": y}, "gate_type": "and"}},
+                },
+            )
+
+    completed = client.get("/export_layout").data
+    # Native FGL export omits dangling gates, but imported FGL can explicitly contain them.
+    partial = ElementTree.fromstring(completed)
+    gates = partial.find("gates")
+    for gate in list(gates):
+        if gate.findtext("type") != "PI" and (gate.findtext("loc/x"), gate.findtext("loc/y")) != ("1", "1"):
+            gates.remove(gate)
+    import_fgl(ElementTree.tostring(partial))
+    for swapped_layers in (False, True):
+        content = ElementTree.fromstring(completed)
+        if swapped_layers:  # Complete external FGL crossings can use the opposite layer convention.
+            for element in [*content.findall(".//loc"), *content.findall(".//signal")]:
+                if (element.findtext("x"), element.findtext("y")) == ("1", "1"):
+                    element.find("z").text = str(1 - int(element.findtext("z")))
+        import_fgl(ElementTree.tostring(content))
+        with client.session_transaction() as session:
+            layout = designer.layouts[session["session_id"]]
+        expected = [(0, 1), (1, 0)] if gate_type == "bufc" else [(1, 0), (0, 1)]
+        for target, origin in zip(((2, 1), (1, 2)), expected, strict=True):
+            wire = next(tile for tile in layout.fanins(target) if (tile.x, tile.y) == (1, 1))
+            source = layout.fanins(wire)[0]
+            assert (source.x, source.y) == origin
+
+
+def test_move_crossing_preserves_native_layer_order(client):
+    layout = designer.cartesian_obstruction_layout(designer.cartesian_gate_layout((3, 3, 1), "2DDWave", "Layout"))
+    for z in (0, 1):
+        layout.create_buf(layout.create_pi("", (z, 0)), (1, 1, z))
+    nodes = [layout.get_node((1, 1, z)) for z in (0, 1)]
+    with client.session_transaction() as session:
+        designer.layouts[session["session_id"]] = layout
+    post(
+        client,
+        "/move_gate",
+        {
+            "source_x": 1,
+            "source_y": 1,
+            "source_gate_type": "bufc",
+            "target_x": 0,
+            "target_y": 0,
+        },
+        success=False,
+    )
+    assert [layout.get_node((1, 1, z)) for z in (0, 1)] == nodes
+    post(client, "/move_gate", {"source_x": 1, "source_y": 1, "source_gate_type": "bufc", "target_x": 2, "target_y": 2})
+    assert [layout.get_node((2, 2, z)) for z in (0, 1)] == nodes
+    assert not layout.fanins((2, 2, 0)) and not layout.fanins((2, 2, 1))
+    assert client.get("/get_layout").get_json()["success"]
 
 
 @pytest.mark.parametrize("multithreading", [False, True])
@@ -224,9 +314,40 @@ def test_exact_defaults_and_unavailable_solver(placed, monkeypatch):
 
         monkeypatch.setattr(designer, "exact_cartesian", capture)
         assert post(placed, "/apply_exact", {"timeout": 1000})["gates"]
+        response = placed.post("/apply_exact", json=[1])
+        assert response.status_code == 400
+        assert "JSON object" in response.get_json()["error"]
     monkeypatch.setattr(designer, "exact_params", None)
     monkeypatch.setattr(designer, "exact_cartesian", None)
     assert "Z3" in post(placed, "/apply_exact", success=False)["error"]
+
+
+@pytest.mark.parametrize(
+    "field,maximum",
+    [
+        ("upper_bound_x", 65535),
+        ("upper_bound_y", 65535),
+        ("num_threads", (1 << (8 * struct.calcsize("P"))) - 1),
+        ("timeout", 4294967295),
+    ],
+)
+def test_exact_requires_positive_native_range_integers(placed, monkeypatch, field, maximum):
+    if designer.exact_params is None:
+        pytest.skip("Pyfiction was built without Exact parameters")
+    original = placed.get("/get_layout").get_json()
+
+    def capture(network, params):
+        assert getattr(params, field) == maximum
+        return designer.orthogonal(network)
+
+    monkeypatch.setattr(designer, "exact_cartesian", capture)
+    for invalid in (0, -1, True, False, 1.5, 1.0, "1", None, maximum + 1):
+        response = placed.post("/apply_exact", json={field: invalid})
+        assert response.status_code == 400, (field, invalid, response.get_json())
+        assert response.get_json()["success"] is False
+        assert field in response.get_json()["error"]
+        assert placed.get("/get_layout").get_json() == original
+    assert post(placed, "/apply_exact", {field: maximum})["gates"]
 
 
 def test_cli(monkeypatch, capsys):

--- a/tests/test_designer.py
+++ b/tests/test_designer.py
@@ -97,6 +97,42 @@ def test_missing_layout_exports_and_session_isolation(placed):
     assert designer.app.secret_key != "your_secret_key"
 
 
+@pytest.mark.parametrize(
+    "route,extra_file",
+    [
+        ("/import_layout", False),
+        ("/import_verilog_code", False),
+        ("/save_verilog_code", False),
+        ("/import_verilog_code", True),
+    ],
+)
+def test_oversized_uploads_rejected_before_parsing(placed, monkeypatch, route, extra_file):
+    original = placed.get("/get_layout").get_json()
+    assert designer.app.config["MAX_CONTENT_LENGTH"] == 5 * 1024 * 1024
+    monkeypatch.setitem(designer.app.config, "MAX_CONTENT_LENGTH", 1024)
+
+    def unexpected_parse(*args, **kwargs):
+        pytest.fail("Oversized requests must be rejected before file streams or native parsing")
+
+    monkeypatch.setattr(designer.app.request_class, "_get_file_stream", unexpected_parse)
+    monkeypatch.setattr(designer, "read_cartesian_fgl_layout", unexpected_parse)
+    monkeypatch.setattr(designer, "read_technology_network", unexpected_parse)
+    if route == "/save_verilog_code":
+        response = placed.post(route, json={"code": "x" * 2048})
+    else:
+        filename = "example.fgl" if route == "/import_layout" else "example.v"
+        data = {"file": (io.BytesIO(VERILOG.encode() if extra_file else b"x" * 2048), filename)}
+        if extra_file:
+            data["ignored"] = (io.BytesIO(b"x" * 2048), "unused.bin")
+        response = placed.post(route, data=data)
+    assert response.status_code == 413
+    assert response.is_json
+    assert response.get_json()["success"] is False
+    assert response.get_json()["error"]
+    assert placed.get("/get_layout").get_json() == original
+    assert placed.get("/get_verilog_code").get_json()["code"] == VERILOG
+
+
 def test_import_verilog_and_safe_layout_edits(client):
     imported = client.post("/import_verilog_code", data={"file": (io.BytesIO(VERILOG.encode()), "example.v")})
     assert imported.get_json() == {"success": True, "code": VERILOG}

--- a/tests/test_designer.py
+++ b/tests/test_designer.py
@@ -270,6 +270,113 @@ def test_move_crossing_preserves_native_layer_order(client):
     assert client.get("/get_layout").get_json()["success"]
 
 
+def test_upper_only_wire_roundtrip_move_connect_and_delete(client):
+    layout = designer.cartesian_obstruction_layout(designer.cartesian_gate_layout((3, 2, 1), "2DDWave", "Layout"))
+    layout.create_pi("a", (0, 0))
+    wire = layout.create_buf(layout.create_pi("b", (0, 1)), (1, 1, 1))
+    layout.create_po(wire, "y", (2, 1))
+    with client.session_transaction() as session:
+        session_id = session["session_id"]
+        designer.layouts[session_id] = layout
+    original = client.get("/get_layout").get_json()
+    upper = next(gate for gate in original["gates"] if (gate["x"], gate["y"]) == (1, 1))
+    assert upper["type"] == "buf" and upper["connections"] == [{"sourceX": 0, "sourceY": 1}]
+    content = client.get("/export_layout").data
+    response = client.post("/import_layout", data={"file": (io.BytesIO(content), "upper.fgl")})
+    assert response.get_json()["success"]
+    assert client.get("/get_layout").get_json() == original
+    layout = designer.layouts[session_id]
+    wire_node = layout.get_node((1, 1, 1))
+    post(client, "/place_gate", {"x": 1, "y": 1, "gate_type": "pi", "params": {}}, success=False)
+    assert client.get("/get_layout").get_json() == original
+    post(
+        client,
+        "/move_gate",
+        {
+            "source_x": 1,
+            "source_y": 1,
+            "source_gate_type": "buf",
+            "target_x": 1,
+            "target_y": 0,
+        },
+    )
+    assert layout.get_node((1, 0, 1)) == wire_node and layout.is_empty_tile((1, 0, 0))
+    assert not layout.fanins((2, 1))
+    post(
+        client,
+        "/connect_gates",
+        {
+            "source_x": 0,
+            "source_y": 0,
+            "source_gate_type": "pi",
+            "target_x": 1,
+            "target_y": 0,
+            "target_gate_type": "buf",
+            "find_path": False,
+        },
+    )
+    assert [(tile.x, tile.y, tile.z) for tile in layout.fanins((1, 0, 1))] == [(0, 0, 0)]
+    post(
+        client,
+        "/move_gate",
+        {
+            "source_x": 2,
+            "source_y": 1,
+            "source_gate_type": "po",
+            "target_x": 2,
+            "target_y": 0,
+        },
+    )
+    post(
+        client,
+        "/connect_gates",
+        {
+            "source_x": 1,
+            "source_y": 0,
+            "source_gate_type": "buf",
+            "target_x": 2,
+            "target_y": 0,
+            "target_gate_type": "po",
+            "find_path": False,
+        },
+    )
+    assert [(tile.x, tile.y, tile.z) for tile in layout.fanins((2, 0))] == [(1, 0, 1)]
+    post(client, "/delete_gate", {"x": 1, "y": 0})
+    assert layout.is_empty_tile((1, 0, 1)) and not layout.fanins((2, 0))
+    assert layout.is_pi(layout.get_node((0, 0))) and layout.is_pi(layout.get_node((0, 1)))
+    assert len(client.get("/get_layout").get_json()["gates"]) == 3
+
+
+@pytest.mark.parametrize("consumer,upper_key", [("buf", "first"), ("and", "first"), ("and", "second")])
+def test_upper_only_wire_feeds_new_consumers(client, consumer, upper_key):
+    layout = designer.cartesian_obstruction_layout(designer.cartesian_gate_layout((2, 2, 1), "2DDWave", "Layout"))
+    layout.create_buf(layout.create_pi("a", (0, 1)), (1, 1, 1))
+    layout.create_pi("b", (2, 0))
+    with client.session_transaction() as session:
+        designer.layouts[session["session_id"]] = layout
+    params = {upper_key: {"position": {"x": 1, "y": 1}, "gate_type": "buf"}}
+    if consumer == "and":
+        params["second" if upper_key == "first" else "first"] = {
+            "position": {"x": 2, "y": 0},
+            "gate_type": "pi",
+        }
+    post(client, "/place_gate", {"x": 2, "y": 1, "gate_type": consumer, "params": params})
+    assert (1, 1, 1) in [(tile.x, tile.y, tile.z) for tile in layout.fanins((2, 1))]
+    original = client.get("/get_layout").get_json()
+    post(
+        client,
+        "/place_gate",
+        {
+            "x": 1,
+            "y": 2,
+            "gate_type": "buf",
+            "params": {"first": {"position": {"x": 1, "y": 1}, "gate_type": "buf"}},
+        },
+        success=False,
+    )  # Upper routing-layer wires still cannot become fanouts.
+    assert client.get("/get_layout").get_json() == original
+
+
 @pytest.mark.parametrize("multithreading", [False, True])
 def test_gold_forwards_multithreading(placed, monkeypatch, multithreading):
     run_gold = designer.graph_oriented_layout_design


### PR DESCRIPTION
## 🔧 Summary

- ⬆️ Require Python 3.11+ and pyfiction 0.8.0+, with support declared for Python 3.11–3.14.
- 📦 Consolidate packaging in `pyproject.toml`, remove unused runtime dependencies and obsolete packaging files, and fix editable installs in the shared `mnt` namespace.
- 🚀 Fix publication of both wheel and source distributions; test installed artifacts in CI, pin Actions, and scope workflow permissions. Preserve both CodeQL language configurations.
- 🧹 Simplify pre-commit configuration around Ruff and focused repository checks.
- ✨ Add the `mnt-designer` CLI alias with host, port, version, and no-browser options; retain `mnt.designer`.
- 🔒 Replace the hard-coded session secret and isolate temporary import/export files per request.
- 🔒 Adopt the upload-size hardening concern from #13 using Flask's native 5 MiB request-body limit, preserve HTTP 413 errors, and show upload/save errors in the UI. Disabling direct-script debug mode is already covered here.
- 🐛 Fix Exact default bounds, GOLD multithreading forwarding, zero-relocation handling, and layout-editing/crossing edge cases.
- 📝 Update installation and hosting guidance, including the existing single-worker, in-memory storage limitation.

The frontend design is unchanged. This PR does not publish a release.

## ✅ Checks

- 🧪 All 14 smoke tests pass on Python 3.11 and 3.14 with pyfiction 0.8.0, including oversized layout/Verilog uploads, editor saves, total multipart size, and preservation of existing work.
- 📦 Clean, non-editable wheel and source-distribution installs pass the same tests, both CLI commands, dependency checks, and homepage/static-asset checks.
- ✅ Wheel and source distribution pass Twine checks; repository pre-commit checks and `git diff --check` pass.
- 🧪 A separate real Exact-solver run produces a small layout that passes strong equivalence checking; the smoke suite also exercises real Orthogonal, GOLD, optimization, and all four export formats.
- 📏 Checked all 955 FGL archive entries against MNT Bench metadata. All 750 layouts with area ≤10,000 tiles fit the cap; the largest is `router_ONE_BEST.fgl` (77 × 102 tiles, 1,765,724 bytes / 1.684 MiB), and imports successfully with the cap enabled.

## 🔒 Upload hardening scope

Supersedes #13. Filename sanitization is unnecessary because uploaded names never determine the saved path; a `.fgl` suffix check would not validate content. The byte limit bounds reads before the native parser, not parser execution cost or layout dimensions. Hosts should also configure a matching reverse-proxy request limit.

Streamed multipart requests without `Content-Length` also return JSON 413. With Flask 3.1.3 / Werkzeug 3.1.8, an oversized streamed JSON body can instead be truncated at the read limit and rejected by JSON decoding; this follows the existing `success: false` error path. The malformed streamed probes remained capped, never reached the native parser, and preserved existing work.
