### PR TITLE
✨ Add on-the-fly SiDB gate design

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,12 @@ Designer converts the layout to hexagonal form and offers SVG or SiQAD (`.sqd`) 
 Verilog remain unchanged. **SiDB layout (Bestagon)** exports the predefined Bestagon library without a gate search.
 
 The search defaults to QuickCell with three canvas SiDBs per gate. You can choose one to three SiDBs or use exhaustive or
-random search. Designer uses the default Bestagon canvas and physical parameters, and predefined complex gates where
-possible. QuickCell and exhaustive search stop after the first solution; random search evaluates at most 10,000
-candidates per gate. Some gate types and orientations are unsupported, and a search may find no implementation.
+random search. Physical parameters are adjustable: relative permittivity εᵣ (default 5.6), Thomas–Fermi screening length
+λTF (5.0 nm), charge-transition energy μ₋ (−0.32 eV), and two or three charge states (default three).
+Designer uses the default Bestagon canvas and predefined complex gates where possible at the default physical settings.
+Changing any physical parameter also searches for crossings and double wires under those conditions, using three canvas
+SiDBs for these complex gates. QuickCell and exhaustive search stop after the first solution; random search evaluates at
+most 10,000 candidates per gate. Some gate types and orientations are unsupported, and a search may find no implementation.
 Designer runs one search at a time in a separate process, stops it after 60 seconds, and discards incomplete results.
 Closing the settings dialog does not cancel the search. Editing can continue; the download uses the layout snapshot
 taken when the search started.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,24 @@ Use `--help` to see the options, or choose another port and open the browser you
 $ mnt-designer --port 5053 --no-browser
 ```
 
+## SiDB gate design
+
+Choose **Export → Design SiDB gates…** to synthesize SiDB implementations for the current gate-level layout.
+Designer converts the layout to hexagonal form and offers SVG or SiQAD (`.sqd`) downloads. The gate-level layout and
+Verilog remain unchanged. **SiDB layout (Bestagon)** exports the predefined Bestagon library without a gate search.
+
+Gate design requires a pyfiction build providing `on_the_fly_sidb_circuit_design` and its parameter bindings.
+The published pyfiction 0.8.0 does not include these bindings; Designer disables this action when they are missing.
+The other Designer features remain available.
+
+The search defaults to QuickCell with three canvas SiDBs per gate. You can choose one to three SiDBs or use exhaustive or
+random search. Designer uses the default Bestagon canvas and physical parameters, and predefined complex gates where
+possible. QuickCell and exhaustive search stop after the first solution; random search evaluates at most 10,000
+candidates per gate. Some gate types and orientations are unsupported, and a search may find no implementation.
+Designer runs one search at a time in a separate process, stops it after 60 seconds, and discards incomplete results.
+Closing the settings dialog does not cancel the search. Editing can continue; the download uses the layout snapshot
+taken when the search started.
+
 ## Development
 
 Clone the repository and install it in a Python 3.11+ virtual environment:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Related publication presented at DATE: [paper](https://www.cda.cit.tum.de/files/
 
 # Usage of MNT Designer
 
-MNT Designer supports Python 3.11–3.14 and uses [pyfiction](https://pypi.org/project/mnt.pyfiction/) 0.8.0 or newer.
+MNT Designer supports Python 3.11–3.14 and uses [pyfiction](https://pypi.org/project/mnt.pyfiction/) 0.9.0 or newer.
 Create a virtual environment using your Python installation:
 
 ```console
@@ -69,10 +69,6 @@ $ mnt-designer --port 5053 --no-browser
 Choose **Export → Design SiDB gates…** to synthesize SiDB implementations for the current gate-level layout.
 Designer converts the layout to hexagonal form and offers SVG or SiQAD (`.sqd`) downloads. The gate-level layout and
 Verilog remain unchanged. **SiDB layout (Bestagon)** exports the predefined Bestagon library without a gate search.
-
-Gate design requires a pyfiction build providing `on_the_fly_sidb_circuit_design` and its parameter bindings.
-The published pyfiction 0.8.0 does not include these bindings; Designer disables this action when they are missing.
-The other Designer features remain available.
 
 The search defaults to QuickCell with three canvas SiDBs per gate. You can choose one to three SiDBs or use exhaustive or
 random search. Designer uses the default Bestagon canvas and physical parameters, and predefined complex gates where

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dynamic = ["version"]
 
 dependencies = [
     "flask>=3.0.0",
-    "mnt.pyfiction>=0.8.0",
+    "mnt.pyfiction>=0.9.0",
 ]
 
 classifiers = [

--- a/src/mnt/designer/app.py
+++ b/src/mnt/designer/app.py
@@ -1,6 +1,7 @@
 import argparse
 import io
 import logging
+import math
 import os
 import re
 import secrets
@@ -1158,6 +1159,25 @@ def design_sidb_layout():
         return jsonify({"success": False, "error": "Choose between 1 and 3 canvas SiDBs per gate."}), 400
     if mode not in sidb_design.MODES or export_format not in ("svg", "sqd"):
         return jsonify({"success": False, "error": "Unsupported gate-design method or export format."}), 400
+    epsilon_r = data.get("epsilon_r", 5.6)
+    lambda_tf = data.get("lambda_tf", 5.0)
+    mu_minus = data.get("mu_minus", -0.32)
+    base = data.get("base", 3)
+    try:
+        finite_parameters = all(
+            type(value) in (int, float) and math.isfinite(value) for value in (epsilon_r, lambda_tf, mu_minus)
+        )
+    except OverflowError:
+        finite_parameters = False
+    if not finite_parameters or epsilon_r <= 0 or lambda_tf <= 0:
+        return jsonify(
+            {
+                "success": False,
+                "error": "Physical parameters must be finite numbers; permittivity and screening length must be positive.",
+            }
+        ), 400
+    if type(base) is not int or base not in (2, 3):
+        return jsonify({"success": False, "error": "Choose 2 or 3 charge states."}), 400
 
     layout = layouts.get(session.get("session_id"))
     if layout is None or not layout.num_pis() or not layout.num_pos():
@@ -1174,6 +1194,10 @@ def design_sidb_layout():
             "image/svg+xml" if export_format == "svg" else "application/xml",
             count,
             mode,
+            epsilon_r,
+            lambda_tf,
+            mu_minus,
+            base,
         )
     except subprocess.TimeoutExpired:
         return jsonify(

--- a/src/mnt/designer/app.py
+++ b/src/mnt/designer/app.py
@@ -5,7 +5,9 @@ import os
 import re
 import secrets
 import struct
+import subprocess
 import tempfile
+import threading
 import uuid
 import webbrowser
 from collections.abc import Sequence
@@ -16,6 +18,7 @@ from pathlib import Path
 from flask import Flask, cli, jsonify, render_template, request, send_file, session
 from werkzeug.exceptions import RequestEntityTooLarge
 
+from mnt.designer import sidb_design
 from mnt.pyfiction import (
     a_star,
     apply_bestagon_library,
@@ -67,6 +70,9 @@ networks = {}
 # In-memory storage for user verilog
 verilogs = {}
 
+# The server uses one worker; run at most one native gate search at a time.
+sidb_design_lock = threading.Lock()
+
 
 @app.errorhandler(RequestEntityTooLarge)
 def request_too_large(_error):
@@ -83,7 +89,7 @@ def index():
     # Assign a unique session ID if not already present
     if "session_id" not in session:
         session["session_id"] = str(uuid.uuid4())
-    return render_template("index.html")
+    return render_template("index.html", sidb_gate_design_available=sidb_design.available())
 
 
 @app.route("/create_layout", methods=["POST"])
@@ -1133,6 +1139,69 @@ def export_sidb_layout():
 
     except Exception:
         return _internal_error_response()
+
+
+@app.route("/design_sidb_layout", methods=["POST"])
+def design_sidb_layout():
+    if not sidb_design.available():
+        return jsonify(
+            {"success": False, "error": "Upgrade pyfiction to a build with on-the-fly SiDB circuit design."}
+        ), 503
+
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({"success": False, "error": "Expected JSON gate-design settings."}), 400
+    count = data.get("number_of_canvas_sidbs", 3)
+    mode = data.get("design_mode", "QUICKCELL")
+    export_format = data.get("export_format", "svg")
+    if type(count) is not int or not 1 <= count <= 3:
+        return jsonify({"success": False, "error": "Choose between 1 and 3 canvas SiDBs per gate."}), 400
+    if mode not in sidb_design.MODES or export_format not in ("svg", "sqd"):
+        return jsonify({"success": False, "error": "Unsupported gate-design method or export format."}), 400
+
+    layout = layouts.get(session.get("session_id"))
+    if layout is None or not layout.num_pis() or not layout.num_pos():
+        return jsonify({"success": False, "error": "Create a connected layout with inputs and outputs first."}), 400
+    if not sidb_design_lock.acquire(blocking=False):
+        return jsonify(
+            {"success": False, "error": "Another SiDB gate design is running. Try again when it finishes."}
+        ), 409
+    try:
+        return _send_layout_file(
+            layout,
+            sidb_design.write_layout,
+            f"layout_sidb_designed.{export_format}",
+            "image/svg+xml" if export_format == "svg" else "application/xml",
+            count,
+            mode,
+        )
+    except subprocess.TimeoutExpired:
+        return jsonify(
+            {
+                "success": False,
+                "error": "Gate design reached the 60-second limit. Try fewer canvas SiDBs or random search.",
+            }
+        ), 504
+    except subprocess.CalledProcessError as error:
+        if error.returncode == 2:
+            return jsonify(
+                {
+                    "success": False,
+                    "error": "No SiDB circuit could be designed with these settings. Try another SiDB count or search method; some gate types and orientations are unsupported.",
+                }
+            ), 422
+        if error.returncode == 3:
+            return jsonify(
+                {
+                    "success": False,
+                    "error": "The layout has design-rule errors. Check and repair the layout before designing SiDB gates.",
+                }
+            ), 422
+        return _internal_error_response(), 500
+    except Exception:
+        return _internal_error_response(), 500
+    finally:
+        sidb_design_lock.release()
 
 
 @app.route("/import_layout", methods=["POST"])

--- a/src/mnt/designer/sidb_design.py
+++ b/src/mnt/designer/sidb_design.py
@@ -1,0 +1,65 @@
+"""Run native SiDB gate design on a layout snapshot with a hard time limit."""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+import mnt.pyfiction as fiction
+
+MODES = ("QUICKCELL", "AUTOMATIC_EXHAUSTIVE_GATE_DESIGNER", "RANDOM")
+TIMEOUT_SECONDS = 60
+
+
+def available() -> bool:
+    """Whether the installed pyfiction provides circuit-design bindings."""
+    return hasattr(fiction, "on_the_fly_sidb_circuit_design") and hasattr(
+        fiction, "on_the_fly_sidb_circuit_design_params"
+    )
+
+
+def write_layout(layout: fiction.cartesian_gate_layout, filename: str, count: int, mode: str) -> None:
+    """Export a snapshot and isolate the native search in a killable process."""
+    source = Path(filename).with_name("input.fgl")
+    fiction.write_fgl_layout(layout, str(source))
+    subprocess.run(
+        [sys.executable, "-m", "mnt.designer.sidb_design", str(source), filename, str(count), mode],
+        check=True,
+        timeout=TIMEOUT_SECONDS,
+        capture_output=True,
+    )
+
+
+def main() -> int:
+    """Design gates for the private FGL snapshot and write SVG or SiQAD output."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source")
+    parser.add_argument("output")
+    parser.add_argument("count", type=int, choices=range(1, 4))
+    parser.add_argument("mode", choices=MODES)
+    args = parser.parse_args()
+    layout = fiction.read_cartesian_fgl_layout(args.source)
+    _, errors = fiction.gate_level_drvs(layout, print_report=False)
+    if errors:
+        return 3
+    try:
+        hex_layout = fiction.hexagonalization(layout)
+        params = fiction.on_the_fly_sidb_circuit_design_params()
+        gate_params = params.sidb_on_the_fly_gate_library_parameters.design_gate_params
+        gate_params.number_of_canvas_sidbs = args.count
+        gate_params.design_mode = getattr(fiction.design_sidb_gates_mode, args.mode)
+        gate_params.maximal_random_design_attempts = 10_000
+        circuit = fiction.on_the_fly_sidb_circuit_design(hex_layout, params)
+    except (RuntimeError, ValueError):
+        return 2
+    if Path(args.output).suffix == ".sqd":
+        fiction.write_sqd_layout(circuit, args.output)
+    else:
+        svg_params = fiction.write_sidb_layout_svg_params()
+        svg_params.color_background = fiction.color_mode.DARK
+        fiction.write_sidb_layout_svg(circuit, args.output, svg_params)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/mnt/designer/sidb_design.py
+++ b/src/mnt/designer/sidb_design.py
@@ -18,12 +18,33 @@ def available() -> bool:
     )
 
 
-def write_layout(layout: fiction.cartesian_gate_layout, filename: str, count: int, mode: str) -> None:
+def write_layout(
+    layout: fiction.cartesian_gate_layout,
+    filename: str,
+    count: int,
+    mode: str,
+    epsilon_r: float,
+    lambda_tf: float,
+    mu_minus: float,
+    base: int,
+) -> None:
     """Export a snapshot and isolate the native search in a killable process."""
     source = Path(filename).with_name("input.fgl")
     fiction.write_fgl_layout(layout, str(source))
     subprocess.run(
-        [sys.executable, "-m", "mnt.designer.sidb_design", str(source), filename, str(count), mode],
+        [
+            sys.executable,
+            "-m",
+            "mnt.designer.sidb_design",
+            str(source),
+            filename,
+            str(count),
+            mode,
+            f"--epsilon-r={epsilon_r}",
+            f"--lambda-tf={lambda_tf}",
+            f"--mu-minus={mu_minus}",
+            f"--base={base}",
+        ],
         check=True,
         timeout=TIMEOUT_SECONDS,
         capture_output=True,
@@ -37,6 +58,10 @@ def main() -> int:
     parser.add_argument("output")
     parser.add_argument("count", type=int, choices=range(1, 4))
     parser.add_argument("mode", choices=MODES)
+    parser.add_argument("--epsilon-r", type=float, default=5.6)
+    parser.add_argument("--lambda-tf", type=float, default=5.0)
+    parser.add_argument("--mu-minus", type=float, default=-0.32)
+    parser.add_argument("--base", type=int, choices=(2, 3), default=3)
     args = parser.parse_args()
     layout = fiction.read_cartesian_fgl_layout(args.source)
     _, errors = fiction.gate_level_drvs(layout, print_report=False)
@@ -45,10 +70,20 @@ def main() -> int:
     try:
         hex_layout = fiction.hexagonalization(layout)
         params = fiction.on_the_fly_sidb_circuit_design_params()
-        gate_params = params.sidb_on_the_fly_gate_library_parameters.design_gate_params
+        library_params = params.sidb_on_the_fly_gate_library_parameters
+        gate_params = library_params.design_gate_params
         gate_params.number_of_canvas_sidbs = args.count
         gate_params.design_mode = getattr(fiction.design_sidb_gates_mode, args.mode)
         gate_params.maximal_random_design_attempts = 10_000
+        physical = gate_params.operational_params.simulation_parameters
+        for name in ("epsilon_r", "lambda_tf", "mu_minus", "base"):
+            value = getattr(args, name)
+            if value != getattr(physical, name):
+                # Predefined crossings are not rechecked under changed physical conditions.
+                library_params.using_predefined_crossing_and_double_wire_if_possible = (
+                    fiction.sidb_complex_gate_design_policy.DESIGN_ON_THE_FLY
+                )
+            setattr(physical, name, value)
         circuit = fiction.on_the_fly_sidb_circuit_design(hex_layout, params)
     except (RuntimeError, ValueError):
         return 2

--- a/src/mnt/designer/static/css/styles.css
+++ b/src/mnt/designer/static/css/styles.css
@@ -160,6 +160,7 @@ a:hover { color: var(--blue-dark); }
 .modal-body { padding: 22px 26px 8px; }
 .modal-footer { padding: 15px 26px; background: #fafbfc; }
 .modal form { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 20px 28px; }
+.modal form > fieldset { grid-column: 1 / -1; }
 .modal form > .mb-4 { margin-bottom: 0 !important; padding-bottom: 20px; border-bottom: 1px solid #eff0f3; min-width: 0; }
 .modal .form-label { font-size: 14px; font-weight: 600; margin-bottom: 9px; }
 .modal .form-check { display: inline-flex; align-items: center; gap: 7px; margin-right: 17px; padding-left: 0; min-height: 27px; }

--- a/src/mnt/designer/static/js/script.js
+++ b/src/mnt/designer/static/js/script.js
@@ -2202,18 +2202,10 @@ endmodule
   });
 
   // Export Layout
-  const exportFormats = {
-    "export-fgl-layout-button": ["/export_layout", "layout.fgl"],
-    "export-dot-layout-button": ["/export_dot_layout", "layout.dot"],
-    "export-qca-layout-button": ["/export_qca_layout", "layout_qca.svg"],
-    "export-sidb-layout-button": ["/export_sidb_layout", "layout_sidb.svg"],
-  };
-  $(Object.keys(exportFormats).map((id) => `#${id}`).join(",")).on("click", async function () {
-    const [route, filename] = exportFormats[this.id];
-    this.disabled = true;
+  async function downloadLayout(route, filename, options) {
     let objectUrl;
     try {
-      const response = await fetch(route);
+      const response = await fetch(route, options);
       if (response.headers.get("content-type")?.includes("application/json")) {
         const result = await response.json();
         throw new Error(result.error || "The layout could not be exported.");
@@ -2226,12 +2218,59 @@ endmodule
       document.body.appendChild(link);
       link.click();
       link.remove();
+    } finally {
+      if (objectUrl) setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
+    }
+  }
+
+  const exportFormats = {
+    "export-fgl-layout-button": ["/export_layout", "layout.fgl"],
+    "export-dot-layout-button": ["/export_dot_layout", "layout.dot"],
+    "export-qca-layout-button": ["/export_qca_layout", "layout_qca.svg"],
+    "export-sidb-layout-button": ["/export_sidb_layout", "layout_sidb.svg"],
+  };
+  $(Object.keys(exportFormats).map((id) => `#${id}`).join(",")).on("click", async function () {
+    const [route, filename] = exportFormats[this.id];
+    this.disabled = true;
+    try {
+      await downloadLayout(route, filename);
       updateMessageArea(`Download started: ${filename}.`, "success");
     } catch (error) {
       updateMessageArea("Could not export layout: " + error.message, "danger");
     } finally {
       this.disabled = false;
-      if (objectUrl) setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
+    }
+  });
+
+  // On-the-fly SiDB gate design uses a server-side layout snapshot.
+  $("#sidb-gate-design-form").on("submit", async function (event) {
+    event.preventDefault();
+    const button = document.getElementById("run-sidb-gate-design");
+    if (button.disabled || !this.reportValidity()) return;
+    const params = {
+      number_of_canvas_sidbs: Number($("#sidb-canvas-count").val()),
+      design_mode: $("#sidb-design-mode").val(),
+      export_format: $("#sidb-export-format").val(),
+    };
+    const filename = `layout_sidb_designed.${params.export_format}`;
+    const controls = this.querySelectorAll("input, select");
+    button.disabled = true;
+    controls.forEach((control) => { control.disabled = true; });
+    $("#sidb-design-running").removeClass("d-none");
+    updateMessageArea("Designing SiDB gates for your layout snapshot. Search is limited to 60 seconds.", "info");
+    try {
+      await downloadLayout("/design_sidb_layout", filename, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(params),
+      });
+      updateMessageArea(`Download started: ${filename}. Your current layout was not replaced.`, "success");
+    } catch (error) {
+      updateMessageArea("Could not design SiDB gates: " + error.message, "danger");
+    } finally {
+      button.disabled = false;
+      controls.forEach((control) => { control.disabled = false; });
+      $("#sidb-design-running").addClass("d-none");
     }
   });
 

--- a/src/mnt/designer/static/js/script.js
+++ b/src/mnt/designer/static/js/script.js
@@ -2243,6 +2243,9 @@ endmodule
   });
 
   // On-the-fly SiDB gate design uses a server-side layout snapshot.
+  $("#sidb-epsilon-r, #sidb-lambda-tf").on("input", function () {
+    this.setCustomValidity(this.valueAsNumber > 0 ? "" : "Enter a value greater than zero.");
+  });
   $("#sidb-gate-design-form").on("submit", async function (event) {
     event.preventDefault();
     const button = document.getElementById("run-sidb-gate-design");
@@ -2251,6 +2254,10 @@ endmodule
       number_of_canvas_sidbs: Number($("#sidb-canvas-count").val()),
       design_mode: $("#sidb-design-mode").val(),
       export_format: $("#sidb-export-format").val(),
+      epsilon_r: Number($("#sidb-epsilon-r").val()),
+      lambda_tf: Number($("#sidb-lambda-tf").val()),
+      mu_minus: Number($("#sidb-mu-minus").val()),
+      base: Number($("#sidb-charge-base").val()),
     };
     const filename = `layout_sidb_designed.${params.export_format}`;
     const controls = this.querySelectorAll("input, select");

--- a/src/mnt/designer/templates/index.html
+++ b/src/mnt/designer/templates/index.html
@@ -1240,7 +1240,7 @@
     </div>
 
     <div class="modal fade" id="sidbGateDesignModal" tabindex="-1" aria-labelledby="sidbGateDesignModalLabel" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+      <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
         <div class="modal-content">
           <div class="modal-header">
             <h2 class="modal-title" id="sidbGateDesignModalLabel">Design SiDB gates</h2>
@@ -1262,6 +1262,31 @@
                   <option value="RANDOM">Random search</option>
                 </select>
               </div>
+              <fieldset class="mb-4" aria-describedby="sidb-physical-parameters-help">
+                <legend class="form-label">Physical parameters</legend>
+                <div class="row g-3">
+                  <div class="col-sm-6">
+                    <label for="sidb-epsilon-r" class="form-label">Relative permittivity εᵣ</label>
+                    <input type="number" id="sidb-epsilon-r" class="form-control" min="0" step="any" value="5.6" required />
+                  </div>
+                  <div class="col-sm-6">
+                    <label for="sidb-lambda-tf" class="form-label">Screening length λ (nm)</label>
+                    <input type="number" id="sidb-lambda-tf" class="form-control" min="0" step="any" value="5.0" required />
+                  </div>
+                  <div class="col-sm-6">
+                    <label for="sidb-mu-minus" class="form-label">Transition energy μ₋ (eV)</label>
+                    <input type="number" id="sidb-mu-minus" class="form-control" step="any" value="-0.32" required />
+                  </div>
+                  <div class="col-sm-6">
+                    <label for="sidb-charge-base" class="form-label">Charge states</label>
+                    <select id="sidb-charge-base" class="form-select" required>
+                      <option value="2">2: negative, neutral</option>
+                      <option value="3" selected>3: negative, neutral, positive</option>
+                    </select>
+                  </div>
+                </div>
+                <small id="sidb-physical-parameters-help" class="form-text text-muted d-block mt-2">Starts with fiction's defaults. Changing these values also searches for crossings and double wires instead of using predefined implementations.</small>
+              </fieldset>
               <div class="mb-4">
                 <label for="sidb-export-format" class="form-label">Download format</label>
                 <select id="sidb-export-format" class="form-select" required>

--- a/src/mnt/designer/templates/index.html
+++ b/src/mnt/designer/templates/index.html
@@ -179,7 +179,11 @@
                   <li><button type="button" id="export-dot-layout-button" class="dropdown-item">DOT layout <span class="export-format">.dot</span></button></li>
                   <li><hr class="dropdown-divider" /></li>
                   <li><button type="button" id="export-qca-layout-button" class="dropdown-item">QCA cell layout <span class="export-format">.svg</span></button></li>
-                  <li><button type="button" id="export-sidb-layout-button" class="dropdown-item">Hexagonal SiDB layout <span class="export-format">.svg</span></button></li>
+                  <li><button type="button" id="export-sidb-layout-button" class="dropdown-item">SiDB layout (Bestagon) <span class="export-format">.svg</span></button></li>
+                  <li><button type="button" id="sidb-gate-design-button" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#sidbGateDesignModal" {% if not sidb_gate_design_available %}disabled aria-describedby="sidb-gate-design-unavailable"{% endif %}>Design SiDB gates…</button></li>
+                  {% if not sidb_gate_design_available %}
+                  <li><p id="sidb-gate-design-unavailable" class="dropdown-item-text small text-muted mb-0">Gate design requires a newer pyfiction build with on-the-fly SiDB support, not included in 0.8.0. Upgrade pyfiction and restart Designer.</p></li>
+                  {% endif %}
                 </ul>
               </div>
             </div>
@@ -1230,6 +1234,51 @@
             >
               Optimize
             </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="modal fade" id="sidbGateDesignModal" tabindex="-1" aria-labelledby="sidbGateDesignModalLabel" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h2 class="modal-title" id="sidbGateDesignModalLabel">Design SiDB gates</h2>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <p>Search for SiDB gate implementations for your layout instead of using the fixed Bestagon library.</p>
+            <form id="sidb-gate-design-form">
+              <div class="mb-4">
+                <label for="sidb-canvas-count" class="form-label">SiDBs in each gate's design canvas</label>
+                <input type="number" id="sidb-canvas-count" class="form-control" min="1" max="3" step="1" value="3" required aria-describedby="sidb-canvas-count-help" />
+                <small id="sidb-canvas-count-help" class="form-text text-muted">Choose 1–3. More SiDBs increase the search space.</small>
+              </div>
+              <div class="mb-4">
+                <label for="sidb-design-mode" class="form-label">Search method</label>
+                <select id="sidb-design-mode" class="form-select" required>
+                  <option value="QUICKCELL" selected>QuickCell</option>
+                  <option value="AUTOMATIC_EXHAUSTIVE_GATE_DESIGNER">Exhaustive search</option>
+                  <option value="RANDOM">Random search</option>
+                </select>
+              </div>
+              <div class="mb-4">
+                <label for="sidb-export-format" class="form-label">Download format</label>
+                <select id="sidb-export-format" class="form-select" required>
+                  <option value="svg" selected>SVG image (.svg)</option>
+                  <option value="sqd">SiQAD layout (.sqd)</option>
+                </select>
+              </div>
+            </form>
+            <p class="small text-muted">Uses a snapshot of your layout when started; you can keep editing. Search is limited to 60 seconds and may not find a solution. Closing this dialog does not cancel the search.</p>
+          </div>
+          <div class="modal-footer">
+            <div id="sidb-design-running" class="w-100 d-none" role="status">
+              <span class="spinner-border spinner-border-sm me-2" aria-hidden="true"></span>Designing gates… The download will start when ready.
+            </div>
+            <div class="modal-status alert w-100 d-none" role="alert"></div>
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            <button type="submit" form="sidb-gate-design-form" id="run-sidb-gate-design" class="btn btn-primary" {% if not sidb_gate_design_available %}disabled{% endif %}>Design &amp; download</button>
           </div>
         </div>
       </div>

--- a/src/mnt/designer/templates/index.html
+++ b/src/mnt/designer/templates/index.html
@@ -182,7 +182,7 @@
                   <li><button type="button" id="export-sidb-layout-button" class="dropdown-item">SiDB layout (Bestagon) <span class="export-format">.svg</span></button></li>
                   <li><button type="button" id="sidb-gate-design-button" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#sidbGateDesignModal" {% if not sidb_gate_design_available %}disabled aria-describedby="sidb-gate-design-unavailable"{% endif %}>Design SiDB gates…</button></li>
                   {% if not sidb_gate_design_available %}
-                  <li><p id="sidb-gate-design-unavailable" class="dropdown-item-text small text-muted mb-0">Gate design requires a newer pyfiction build with on-the-fly SiDB support, not included in 0.8.0. Upgrade pyfiction and restart Designer.</p></li>
+                  <li><p id="sidb-gate-design-unavailable" class="dropdown-item-text small text-muted mb-0">Gate design requires pyfiction 0.9.0 or newer. Upgrade pyfiction and restart Designer.</p></li>
                   {% endif %}
                 </ul>
               </div>

--- a/tests/frontend_smoke.cjs
+++ b/tests/frontend_smoke.cjs
@@ -246,4 +246,73 @@ context.subject.replaceEditorCode("unsaved circuit");
     assert.equal(editor.getValue(), "unsaved circuit", "failed export must preserve editor contents");
   }
   console.log("PASS: JSON and HTTP export failures preserve the page/editor and restore the export button");
+
+  const values = {
+    "#sidb-canvas-count": "3", "#sidb-design-mode": "QUICKCELL", "#sidb-export-format": "svg",
+  };
+  const button = { disabled: false }, controls = [{ disabled: false }, { disabled: false }, { disabled: false }];
+  const downloads = [], requests = [];
+  let submit, formValid = false, running = false, finishRequest, feedback;
+  const form = { reportValidity: () => formValid, querySelectorAll: () => controls };
+  const gateDesign = {
+    $: (selector) => ({
+      on(_event, callback) { if (selector === "#sidb-gate-design-form") submit = callback; },
+      val: () => values[selector],
+      removeClass() { running = true; }, addClass() { running = false; },
+    }),
+    document: {
+      getElementById(id) { assert.equal(id, "run-sidb-gate-design"); return button; },
+      createElement: () => ({ click() { downloads.push(this.download); }, remove() {} }),
+      body: { appendChild() {} },
+    },
+    URL: { createObjectURL: () => "blob:designed-layout", revokeObjectURL() {} },
+    setTimeout(callback) { callback(); },
+    updateMessageArea(message, type) { feedback = { message, type }; },
+    updateLayout() { assert.fail("gate design must not overwrite the editable layout"); },
+    fetch(route, options) {
+      assert.equal(route, "/design_sidb_layout");
+      assert.equal(options.method, "POST");
+      assert.equal(options.headers["Content-Type"], "application/json");
+      requests.push(JSON.parse(options.body));
+      return new Promise((resolve) => { finishRequest = resolve; });
+    },
+  };
+  vm.runInNewContext(exportCode, gateDesign);
+  const clickDesign = () => submit.call(form, { preventDefault() {} });
+  await clickDesign();
+  assert.equal(requests.length, 0, "invalid input must not submit a search");
+  formValid = true;
+  button.disabled = true;
+  await clickDesign();
+  assert.equal(requests.length, 0, "unavailable gate design must not submit a search");
+  button.disabled = false;
+
+  for (const outcome of ["error", "svg", "sqd"]) {
+    values["#sidb-export-format"] = outcome === "error" ? "svg" : outcome;
+    values["#sidb-design-mode"] = outcome === "sqd" ? "RANDOM" : outcome === "error" ? "AUTOMATIC_EXHAUSTIVE_GATE_DESIGNER" : "QUICKCELL";
+    values["#sidb-canvas-count"] = outcome === "error" ? "1" : "3";
+    const request = clickDesign();
+    assert.equal(button.disabled, true);
+    assert.ok(controls.every((control) => control.disabled));
+    assert.equal(running, true);
+    const count = requests.length;
+    await clickDesign();
+    assert.equal(requests.length, count, "a duplicate click must not start another search");
+    assert.deepEqual(requests.at(-1), {
+      number_of_canvas_sidbs: Number(values["#sidb-canvas-count"]),
+      design_mode: values["#sidb-design-mode"], export_format: values["#sidb-export-format"],
+    });
+    finishRequest(outcome === "error"
+      ? { ok: false, status: 400, headers: { get: () => "application/json" }, json: async () => ({ success: false, error: "No SiDB implementation found." }) }
+      : { ok: true, headers: { get: () => "application/octet-stream" }, blob: async () => ({}) });
+    await request;
+    assert.equal(button.disabled, false);
+    assert.ok(controls.every((control) => !control.disabled));
+    assert.equal(running, false);
+    assert.equal(feedback.type, outcome === "error" ? "danger" : "success");
+    if (outcome === "error") assert.match(feedback.message, /No SiDB implementation found/);
+    else assert.equal(downloads.at(-1), `layout_sidb_designed.${outcome}`);
+  }
+  assert.equal(downloads.length, 2);
+  console.log("PASS: SiDB design validates inputs, blocks duplicate searches, restores controls on errors, and downloads SVG/SiQAD without changing the layout");
 })().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/tests/frontend_smoke.cjs
+++ b/tests/frontend_smoke.cjs
@@ -249,14 +249,18 @@ context.subject.replaceEditorCode("unsaved circuit");
 
   const values = {
     "#sidb-canvas-count": "3", "#sidb-design-mode": "QUICKCELL", "#sidb-export-format": "svg",
+    "#sidb-epsilon-r": "5.6", "#sidb-lambda-tf": "5.0", "#sidb-mu-minus": "-0.32", "#sidb-charge-base": "3",
   };
-  const button = { disabled: false }, controls = [{ disabled: false }, { disabled: false }, { disabled: false }];
+  const button = { disabled: false }, controls = Object.keys(values).map(() => ({ disabled: false }));
   const downloads = [], requests = [];
-  let submit, formValid = false, running = false, finishRequest, feedback;
+  let submit, validatePositive, formValid = false, running = false, finishRequest, feedback;
   const form = { reportValidity: () => formValid, querySelectorAll: () => controls };
   const gateDesign = {
     $: (selector) => ({
-      on(_event, callback) { if (selector === "#sidb-gate-design-form") submit = callback; },
+      on(_event, callback) {
+        if (selector === "#sidb-gate-design-form") submit = callback;
+        if (selector === "#sidb-epsilon-r, #sidb-lambda-tf") validatePositive = callback;
+      },
       val: () => values[selector],
       removeClass() { running = true; }, addClass() { running = false; },
     }),
@@ -278,6 +282,11 @@ context.subject.replaceEditorCode("unsaved circuit");
     },
   };
   vm.runInNewContext(exportCode, gateDesign);
+  for (const value of [0, -1, NaN, 5.6, 1e-9]) {
+    let validationMessage;
+    validatePositive.call({ valueAsNumber: value, setCustomValidity(message) { validationMessage = message; } });
+    assert.equal(validationMessage, value > 0 ? "" : "Enter a value greater than zero.");
+  }
   const clickDesign = () => submit.call(form, { preventDefault() {} });
   await clickDesign();
   assert.equal(requests.length, 0, "invalid input must not submit a search");
@@ -291,6 +300,9 @@ context.subject.replaceEditorCode("unsaved circuit");
     values["#sidb-export-format"] = outcome === "error" ? "svg" : outcome;
     values["#sidb-design-mode"] = outcome === "sqd" ? "RANDOM" : outcome === "error" ? "AUTOMATIC_EXHAUSTIVE_GATE_DESIGNER" : "QUICKCELL";
     values["#sidb-canvas-count"] = outcome === "error" ? "1" : "3";
+    if (outcome === "sqd") Object.assign(values, {
+      "#sidb-epsilon-r": "6.2", "#sidb-lambda-tf": "7.0", "#sidb-mu-minus": "-2.8e-1", "#sidb-charge-base": "2",
+    });
     const request = clickDesign();
     assert.equal(button.disabled, true);
     assert.ok(controls.every((control) => control.disabled));
@@ -301,6 +313,8 @@ context.subject.replaceEditorCode("unsaved circuit");
     assert.deepEqual(requests.at(-1), {
       number_of_canvas_sidbs: Number(values["#sidb-canvas-count"]),
       design_mode: values["#sidb-design-mode"], export_format: values["#sidb-export-format"],
+      epsilon_r: outcome === "sqd" ? 6.2 : 5.6, lambda_tf: outcome === "sqd" ? 7 : 5,
+      mu_minus: outcome === "sqd" ? -0.28 : -0.32, base: outcome === "sqd" ? 2 : 3,
     });
     finishRequest(outcome === "error"
       ? { ok: false, status: 400, headers: { get: () => "application/json" }, json: async () => ({ success: false, error: "No SiDB implementation found." }) }

--- a/tests/test_designer.py
+++ b/tests/test_designer.py
@@ -2,6 +2,7 @@
 
 import io
 import struct
+import subprocess
 from importlib.metadata import version
 from xml.etree import ElementTree
 
@@ -100,6 +101,73 @@ def test_exports_and_fgl_roundtrip(placed, tmp_path, monkeypatch):
     imported = placed.post("/import_layout", data={"file": (io.BytesIO(exports["/export_layout"]), "example.fgl")})
     assert imported.get_json()["success"]
     assert placed.get("/get_layout").get_json() == original
+
+
+@pytest.mark.skipif(not designer.sidb_design.available(), reason="pyfiction lacks on-the-fly circuit-design bindings")
+@pytest.mark.parametrize("export_format", ["svg", "sqd"])
+def test_sidb_circuit_design_exports_snapshot(placed, export_format):
+    original = placed.get("/get_layout").get_json()
+    response = placed.post("/design_sidb_layout", json={"export_format": export_format})
+    assert response.status_code == 200, response.get_json()
+    assert f"layout_sidb_designed.{export_format}" in response.headers["Content-Disposition"]
+    root = ElementTree.fromstring(response.data)
+    assert root.tag.endswith("svg") if export_format == "svg" else root.tag == "siqad"
+    assert placed.get("/get_layout").get_json() == original
+    assert placed.get("/get_verilog_code").get_json()["code"] == VERILOG
+
+
+def test_sidb_design_missing_capability_layout_and_busy(placed, monkeypatch):
+    monkeypatch.setattr(designer.sidb_design, "available", lambda: False)
+    assert placed.post("/design_sidb_layout", json={}).status_code == 503
+    monkeypatch.setattr(designer.sidb_design, "available", lambda: True)
+    with designer.app.test_client() as other:
+        assert other.post("/design_sidb_layout", json={}).status_code == 400
+    with designer.sidb_design_lock:
+        assert placed.post("/design_sidb_layout", json={}).status_code == 409
+
+
+@pytest.mark.parametrize(
+    "settings",
+    [
+        [],
+        {"number_of_canvas_sidbs": True},
+        {"number_of_canvas_sidbs": "1"},
+        {"number_of_canvas_sidbs": 0},
+        {"number_of_canvas_sidbs": 4},
+        {"design_mode": "PRUNING_ONLY"},
+        {"design_mode": []},
+        {"export_format": "../layout"},
+    ],
+)
+def test_sidb_design_rejects_invalid_settings(placed, monkeypatch, settings):
+    monkeypatch.setattr(designer.sidb_design, "available", lambda: True)
+    response = placed.post("/design_sidb_layout", json=settings)
+    assert response.status_code == 400
+    assert response.get_json()["success"] is False
+
+
+@pytest.mark.parametrize("exit_code,status", [(2, 422), (3, 422), (1, 500), (None, 504)])
+def test_sidb_design_failure_releases_lock_and_preserves_layout(placed, monkeypatch, tmp_path, exit_code, status):
+    original = placed.get("/get_layout").get_json()
+    monkeypatch.setattr(designer.sidb_design, "available", lambda: True)
+    monkeypatch.setattr(designer.tempfile, "tempdir", str(tmp_path))
+
+    def fail(command, **kwargs):
+        assert kwargs["timeout"] == 60
+        assert kwargs["check"]
+        if exit_code is None:
+            raise subprocess.TimeoutExpired(command, 60)
+        raise subprocess.CalledProcessError(exit_code, command, stderr=b"private details")
+
+    monkeypatch.setattr(designer.sidb_design.subprocess, "run", fail)
+    response = placed.post("/design_sidb_layout", json={})
+    assert response.status_code == status
+    assert response.get_json()["success"] is False
+    assert b"private details" not in response.data
+    assert not designer.sidb_design_lock.locked()
+    assert not list(tmp_path.iterdir())
+    assert placed.get("/get_layout").get_json() == original
+    assert placed.get("/export_sidb_layout").status_code == 200
 
 
 def test_missing_layout_exports_and_session_isolation(placed):

--- a/tests/test_designer.py
+++ b/tests/test_designer.py
@@ -3,6 +3,7 @@
 import io
 import struct
 import subprocess
+import sys
 from importlib.metadata import version
 from xml.etree import ElementTree
 
@@ -106,13 +107,44 @@ def test_exports_and_fgl_roundtrip(placed, tmp_path, monkeypatch):
 @pytest.mark.parametrize("export_format", ["svg", "sqd"])
 def test_sidb_circuit_design_exports_snapshot(placed, export_format):
     original = placed.get("/get_layout").get_json()
-    response = placed.post("/design_sidb_layout", json={"export_format": export_format})
+    settings = {"export_format": export_format}
+    if export_format == "sqd":
+        settings.update(epsilon_r=5.7, lambda_tf=5.1, mu_minus=-0.31, base=2)
+    response = placed.post("/design_sidb_layout", json=settings)
     assert response.status_code == 200, response.get_json()
     assert f"layout_sidb_designed.{export_format}" in response.headers["Content-Disposition"]
     root = ElementTree.fromstring(response.data)
     assert root.tag.endswith("svg") if export_format == "svg" else root.tag == "siqad"
     assert placed.get("/get_layout").get_json() == original
     assert placed.get("/get_verilog_code").get_json()["code"] == VERILOG
+
+
+@pytest.mark.parametrize("settings", [{}, {"epsilon_r": 6.2, "lambda_tf": 4.2, "mu_minus": -1e-7, "base": 2}])
+def test_sidb_physical_settings_reach_native_api(placed, monkeypatch, settings):
+    received = {}
+    fiction = designer.sidb_design.fiction
+
+    def inspect_parameters(_layout, params):
+        library = params.sidb_on_the_fly_gate_library_parameters
+        physical = library.design_gate_params.operational_params.simulation_parameters
+        received.update({name: getattr(physical, name) for name in ("epsilon_r", "lambda_tf", "mu_minus", "base")})
+        expected_policy = (
+            fiction.sidb_complex_gate_design_policy.DESIGN_ON_THE_FLY
+            if settings
+            else fiction.sidb_complex_gate_design_policy.USING_PREDEFINED
+        )
+        assert library.using_predefined_crossing_and_double_wire_if_possible == expected_policy
+        raise ValueError("Stop after inspecting the native parameters")
+
+    def run_worker(command, **_kwargs):
+        monkeypatch.setattr(sys, "argv", command[2:])
+        assert designer.sidb_design.main() == 2
+        raise subprocess.CalledProcessError(2, command)
+
+    monkeypatch.setattr(fiction, "on_the_fly_sidb_circuit_design", inspect_parameters)
+    monkeypatch.setattr(designer.sidb_design.subprocess, "run", run_worker)
+    assert placed.post("/design_sidb_layout", json=settings).status_code == 422
+    assert received == (settings or {"epsilon_r": 5.6, "lambda_tf": 5.0, "mu_minus": -0.32, "base": 3})
 
 
 def test_sidb_design_missing_capability_layout_and_busy(placed, monkeypatch):
@@ -136,6 +168,19 @@ def test_sidb_design_missing_capability_layout_and_busy(placed, monkeypatch):
         {"design_mode": "PRUNING_ONLY"},
         {"design_mode": []},
         {"export_format": "../layout"},
+        {"epsilon_r": 0},
+        {"lambda_tf": -1},
+        {"lambda_tf": None},
+        {"epsilon_r": True},
+        {"mu_minus": "-0.32"},
+        {"mu_minus": []},
+        {"mu_minus": float("inf")},
+        {"mu_minus": float("nan")},
+        {"epsilon_r": 10**400},
+        {"base": 4},
+        {"base": True},
+        {"base": 2.0},
+        {"base": "2"},
     ],
 )
 def test_sidb_design_rejects_invalid_settings(placed, monkeypatch, settings):

--- a/tests/test_designer.py
+++ b/tests/test_designer.py
@@ -103,7 +103,6 @@ def test_exports_and_fgl_roundtrip(placed, tmp_path, monkeypatch):
     assert placed.get("/get_layout").get_json() == original
 
 
-@pytest.mark.skipif(not designer.sidb_design.available(), reason="pyfiction lacks on-the-fly circuit-design bindings")
 @pytest.mark.parametrize("export_format", ["svg", "sqd"])
 def test_sidb_circuit_design_exports_snapshot(placed, export_format):
     original = placed.get("/get_layout").get_json()


### PR DESCRIPTION
Integrates the circuit-design bindings merged in https://github.com/cda-tum/fiction/pull/1203 with a QuickCell gate-design dialog and SVG/SiQAD downloads. Searches use a layout snapshot, a separate process and a 60-second limit; Bestagon export remains available.

The dialog exposes canvas SiDB count, search method, relative permittivity, screening length, charge-transition energy, and two or three charge states. Physical inputs are validated before launching a search. Custom physical settings also trigger design of crossings and double wires instead of reusing predefined implementations that were not checked under those conditions.

Requires the upcoming `mnt.pyfiction>=0.9.0` release, with no Git dependency. Wait for 0.9.0 to be published on PyPI before merging, then rerun the package-install checks. Local validation against the identical merged fiction source passes all 64 Python tests, including real default-parameter SVG and custom-parameter SiQAD exports, plus 8 frontend smoke groups and all repository lint checks. Playwright verified real downloads, parameter forwarding, input validation, error recovery, layout preservation, and desktop/mobile dialog behavior. Wheel/source-distribution builds were verified when preparing the 0.9.0 dependency requirement.

AI-assisted implementation and review; automated checks ran locally. Human review is pending.